### PR TITLE
App stops when all windows are closed on Mac OS X

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -15,9 +15,7 @@ var mainWindow = null;
 var appArgs = JSON.parse(fs.readFileSync(APP_ARGS_FILE_PATH, 'utf8'));
 
 app.on('window-all-closed', function() {
-    if (process.platform != 'darwin') {
-        app.quit();
-    }
+    app.quit();
 });
 
 app.on('ready', function() {
@@ -45,10 +43,18 @@ app.on('ready', function() {
             app.dock.setBadge('');
         }
     });
+
+    app.on('before-quit', function() {
+        allowClose = true; // Set allowClose=true so we know we can quit (when on Mac OS X)
+        if (mainWindow) {
+            mainWindow.close();
+            mainWindow = null;
+        }
+    });
     
-    // on Mac OS X hide window instead of clising
+    // on Mac OS X hide window instead of closing unless quitting using dock/menu
     mainWindow.on('close', function(e) {
-        if (process.platform === 'darwin') {
+        if (process.platform === 'darwin' && !allowClose) {
             mainWindow.hide();
             e.preventDefault();
         }

--- a/app/main.js
+++ b/app/main.js
@@ -59,7 +59,3 @@ ipc.on('notification-message', function(event, arg) {
         }
     }
 });
-
-app.on('window-all-closed', function() {
-    app.quit();
-});

--- a/app/main.js
+++ b/app/main.js
@@ -45,6 +45,21 @@ app.on('ready', function() {
             app.dock.setBadge('');
         }
     });
+    
+    // on Mac OS X hide window instead of clising
+    mainWindow.on('close', function(e) {
+        if (process.platform === 'darwin') {
+            mainWindow.hide();
+            e.preventDefault();
+        }
+    });
+
+    // on Mac OSX X show window when clicked on icon
+    if (process.platform === 'darwin') {
+        app.on('activate', function(e) {
+            mainWindow.show();
+        });
+    }
 
     mainWindow.on('closed', function() {
         mainWindow = null;


### PR DESCRIPTION
There are 2 functions bound to the window-all-closed event. The last one stops the app on the window-all-closed event. I removed one.