### PR TITLE
Allow intranet URLs

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -115,7 +115,7 @@ function normalizeUrl(testUrl) {
     if (!parsed.protocol) {
         normalized = 'http://' + normalized;
     }
-    if (!validator.isURL(normalized, {require_protocol: true})) {
+    if (!validator.isURL(normalized, {require_protocol: true, require_tld: true})) {
         throw `Your Url: "${normalized}" is invalid!`;
     }
     return normalized;

--- a/src/options.js
+++ b/src/options.js
@@ -115,7 +115,7 @@ function normalizeUrl(testUrl) {
     if (!parsed.protocol) {
         normalized = 'http://' + normalized;
     }
-    if (!validator.isURL(normalized, {require_protocol: true, require_tld: true})) {
+    if (!validator.isURL(normalized, {require_protocol: true, require_tld: false})) {
         throw `Your Url: "${normalized}" is invalid!`;
     }
     return normalized;


### PR DESCRIPTION
This could be a great way to package intranet applications into electron apps. Added `require_tld` validator config setting to allow those intranet locations without a TLD to be packaged.