### PR TITLE
Fixes the issue with "/"'s in the page title

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -103,7 +103,7 @@ function getTitle(url, callback) {
         }
 
         const $ = cheerio.load(body);
-        const pageTitle = $("title").text();
+        const pageTitle = $("title").text().replace(/\//g, "");
         callback(null, pageTitle);
     });
 }


### PR DESCRIPTION
This commit resolves an bug where the page title would cause a filepaths
issue due to it having a forward slash.

The code committed here uses a simple regular expression to find all
instances of forward slashes in the page title and replace them with an
empty string.

Resolves #22

For more on this, please see:
https://github.com/jiahaog/nativefier/issues/22