### PR TITLE
Adding hide/show menu bar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ Width of the packaged application, defaults to `1280px`.
 
 Height of the packaged application, defaults to `800px`.
 
+#### [show-menu-bar]
+
+```
+-m, --show-menu-bar
+```
+
+Specifies if the menu bar should be shown.
+
 #### [user-agent]
 
 ```

--- a/app/nativefier.json
+++ b/app/nativefier.json
@@ -4,5 +4,6 @@
   "badge": false,
   "width": 1280,
   "height": 800,
+  "showMenuBar": false,
   "showDevTools": false
 }

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -54,6 +54,7 @@ app.on('ready', function () {
         {
             width: appArgs.width || 1280,
             height: appArgs.height || 800,
+            'auto-hide-menu-bar': ! appArgs.showMenuBar,
             'web-preferences': {
                 javascript: true,
                 plugins: true,

--- a/src/buildApp.js
+++ b/src/buildApp.js
@@ -31,7 +31,7 @@ function buildApp(options, callback) {
 
     async.waterfall([
         callback => {
-            copyPlaceholderApp(options.dir, tmpPath, options.name, options.targetUrl, options.badge, options.counter, options.width, options.height, options.userAgent, callback);
+            copyPlaceholderApp(options.dir, tmpPath, options.name, options.targetUrl, options.badge, options.counter, options.width, options.height, options.showMenuBar, options.userAgent, callback);
         },
 
         (tempDir, callback) => {
@@ -64,10 +64,11 @@ function buildApp(options, callback) {
  * @param {boolean} counter
  * @param {number} width
  * @param {number} height
+ * @param {boolean} showMenuBar
  * @param {string} userAgent
  * @param {tempDirCallback} callback
  */
-function copyPlaceholderApp(srcAppDir, tempDir, name, targetURL, badge, counter, width, height, userAgent, callback) {
+function copyPlaceholderApp(srcAppDir, tempDir, name, targetURL, badge, counter, width, height, showMenuBar, userAgent, callback) {
     const loadedPackageJson = packageJson;
     copy(srcAppDir, tempDir, function(error) {
         if (error) {
@@ -83,6 +84,7 @@ function copyPlaceholderApp(srcAppDir, tempDir, name, targetURL, badge, counter,
             counter: counter,
             width: width,
             height: height,
+            showMenuBar: showMenuBar,
             userAgent: userAgent,
             nativefierVersion: loadedPackageJson.version
         };

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,7 @@ function main(program) {
                 program.counter,
                 program.width,
                 program.height,
+                program.showMenuBar,
                 program.userAgent,
                 program.honest,
                 callback);
@@ -40,7 +41,6 @@ function main(program) {
             console.error(error);
             return;
         }
-
         console.log(`App built to ${appPath}`);
     });
 }
@@ -64,6 +64,7 @@ if (require.main === module) {
         .option('-i, --icon <value>', 'the icon file to use as the icon for the app (should be a .icns file on OSX)')
         .option('-w, --width <value>', 'set window width, defaults to 1280px', parseInt)
         .option('-h, --height <value>', 'set window height, defaults to 800px', parseInt)
+        .option('-m, --show-menu-bar', 'set menu bar visible, defaults to false')
         .option('-u, --user-agent <value>', 'set the user agent string for the app')
         .option('--honest', 'prevent the nativefied app from changing the user agent string to masquerade as a regular chrome browser')
         .parse(process.argv);

--- a/src/options.js
+++ b/src/options.js
@@ -23,6 +23,7 @@ function optionsFactory(name,
                         counter = false,
                         width = 1280,
                         height = 800,
+                        showMenuBar = false,
                         userAgent,
                         honest = false,
                         callback) {
@@ -63,6 +64,7 @@ function optionsFactory(name,
         counter: counter,
         width: width,
         height: height,
+        showMenuBar: showMenuBar,
         userAgent: userAgent
     };
 


### PR DESCRIPTION
This PR closes #41.

It adds the `-m`, `--show-menu-bar` option in order to make the menu bar visible. By default, it's hidden.