### PR TITLE
Expose main instead of buildApp

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('lib/main.js');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "native",
     "wrapper"
   ],
-  "main": "lib/buildApp.js",
+  "main": "./index.js",
   "scripts": {
     "dev-up": "npm install && (cd app && npm install)",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,47 +2,8 @@
 
 import path from 'path';
 import program from 'commander';
-import async from 'async';
-
-import optionsFactory from './options';
-import buildApp from './buildApp';
-
+import main from './main'
 const packageJson = require(path.join('..', 'package'));
-
-function main(program) {
-
-    async.waterfall([
-        callback => {
-            optionsFactory(
-                program.appName,
-                program.targetUrl,
-                program.platform,
-                program.arch,
-                program.electronVersion,
-                program.outDir,
-                program.overwrite,
-                program.conceal,
-                program.icon,
-                program.counter,
-                program.width,
-                program.height,
-                program.userAgent,
-                program.honest,
-                callback);
-        },
-
-        (options, callback) => {
-            buildApp(options, callback);
-        }
-    ], (error, appPath) => {
-        if (error) {
-            console.error(error);
-            return;
-        }
-
-        console.log(`App built to ${appPath}`);
-    });
-}
 
 if (require.main === module) {
     program

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,38 @@
+import optionsFactory from './options';
+import buildApp from './buildApp';
+import async from 'async';
+
+export default function main(program) {
+
+    async.waterfall([
+        callback => {
+            optionsFactory(
+                program.appName,
+                program.targetUrl,
+                program.platform,
+                program.arch,
+                program.electronVersion,
+                program.outDir,
+                program.overwrite,
+                program.conceal,
+                program.icon,
+                program.counter,
+                program.width,
+                program.height,
+                program.userAgent,
+                program.honest,
+                callback);
+        },
+
+        (options, callback) => {
+            buildApp(options, callback);
+        }
+    ], (error, appPath) => {
+        if (error) {
+            console.error(error);
+            return;
+        }
+
+        console.log(`App built to ${appPath}`);
+    });
+}


### PR DESCRIPTION
- Refactored `main` function into another file
- Expose `main` instead of `buildApp` to utilize `optionsFactory`