### PR TITLE
Fix -h option's conflict from Issue #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Use a counter that persists even with window focus for the application badge for
 #### [width]
 
 ```
--w, --width <value>
+--width <value>
 ```
 
 Width of the packaged application, defaults to `1280px`.
@@ -154,7 +154,7 @@ Width of the packaged application, defaults to `1280px`.
 #### [height]
 
 ```
--h, --height <value>
+--height <value>
 ```
 
 Height of the packaged application, defaults to `800px`.

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,8 +60,8 @@ if (require.main === module) {
         .option('-c, --conceal', 'packages the source code within your app into an archive, defaults to false, see http://electron.atom.io/docs/v0.36.0/tutorial/application-packaging/')
         .option('--counter', 'if the target app should use a persistant counter badge in the dock (OSX only), defaults to false')
         .option('-i, --icon <value>', 'the icon file to use as the icon for the app (should be a .icns file on OSX)')
-        .option('-w, --width <value>', 'set window width, defaults to 1280px', parseInt)
-        .option('-h, --height <value>', 'set window height, defaults to 800px', parseInt)
+        .option('--width <value>', 'set window width, defaults to 1280px', parseInt)
+        .option('--height <value>', 'set window height, defaults to 800px', parseInt)
         .option('-u, --user-agent <value>', 'set the user agent string for the app')
         .option('--honest', 'prevent the nativefied app from changing the user agent string to masquerade as a regular chrome browser')
         .parse(process.argv);


### PR DESCRIPTION
## overview
There're two `-h` options we can choose on cli :

```
-h, --help                      output usage information
...
-h, --height <value>            set window height, defaults to 800px
```


`-h, --help` option is automatically added by `npm commander` module and it seems to be difficult to change its syntax.

So , I'd like to change `src/cli.js` to fix these options to avoid conflict :

`-h, --height <value>`  => `--height <value>`
`-w, --width <value>`   => `--width <value>`        (to make syntax even)

also I changed usage manual in readme.md.

This problem is reported from Issue #64