### PR TITLE
counter: Allow for [x] and {x} forms of notification count

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -72,7 +72,7 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
             }
 
             if (options.counter) {
-                const itemCountRegex = /[\(](\d*?)[\)]/;
+                const itemCountRegex = /[\(\[{](\d*?)[}\]\)]/;
                 const match = itemCountRegex.exec(mainWindow.getTitle());
                 if (match) {
                     setDockBadge(match[1]);


### PR DESCRIPTION
This PR adds support for [x] and {x} forms of notification counters in the page title, instead of just (x).