### PR TITLE
Feature/disable web security

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,12 +230,12 @@ If this flag is passed, it will not override the user agent.
 ```
 Forces the packaged app to ignore certificate errors.
 
-#### [insecure-content]
+#### [disable-web-security]
 
 ```
---insecure-content
+--disable-web-security
 ```
-Forces the packaged app to ignore content errors.
+Forces the packaged app to ignore web security errors.
 
 ## Programmatic API
 
@@ -267,6 +267,7 @@ var options = {
     showMenuBar: false,
     userAgent: null,
     insecure: false,
+    disableWebSecurity: false,
     honest: false
 };
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ If this flag is passed, it will not override the user agent.
 ```
 Forces the packaged app to ignore certificate errors.
 
+#### [insecure-content]
+
+```
+--insecure-content
+```
+Forces the packaged app to ignore content errors.
+
 ## Programmatic API
 
 You can use the Nativefier programmatic API as well.

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -36,6 +36,7 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
             plugins: true,
             // node globals causes problems with sites like messenger.com
             nodeIntegration: false,
+            webSecurity: !options.disableWebSecurity,
             preload: path.join(__dirname, 'static', 'preload.js')
         },
         // after webpack path here should reference `resources/app/`

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -39,7 +39,7 @@ function changeAppPackageJsonName(appPath, name) {
 /**
  * Only picks certain app args to pass to nativefier.json
  * @param options
- * @returns {{name: (*|string), targetUrl: (string|*), counter: *, width: *, height: *, showMenuBar: *, userAgent: *, nativefierVersion: *, insecure: *}}
+ * @returns {{name: (*|string), targetUrl: (string|*), counter: *, width: *, height: *, showMenuBar: *, userAgent: *, nativefierVersion: *, insecure: *, disableWebSecurity: *}}
  */
 function selectAppArgs(options) {
     return {
@@ -51,7 +51,8 @@ function selectAppArgs(options) {
         showMenuBar: options.showMenuBar,
         userAgent: options.userAgent,
         nativefierVersion: options.nativefierVersion,
-        insecure: options.insecure
+        insecure: options.insecure,
+        disableWebSecurity: options.disableWebSecurity
     };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -29,6 +29,7 @@ if (require.main === module) {
         .option('-u, --user-agent <value>', 'set the user agent string for the app')
         .option('--honest', 'prevent the nativefied app from changing the user agent string to masquerade as a regular chrome browser')
         .option('--insecure', 'ignore certificate related errors')
+        .option('--disable-web-security', 'enable loading of insecure content, defaults to false')
         .parse(process.argv);
 
     if (!process.argv.slice(2).length) {

--- a/src/options.js
+++ b/src/options.js
@@ -47,7 +47,8 @@ function optionsFactory(inpOptions, callback) {
         height: inpOptions.height || 800,
         showMenuBar: inpOptions.showMenuBar || false,
         userAgent: inpOptions.userAgent || getFakeUserAgent(),
-        insecure: inpOptions.insecure || false
+        insecure: inpOptions.insecure || false,
+        disableWebSecurity: inpOptions.disableWebSecurity || false
     };
 
     if (inpOptions.honest) {


### PR DESCRIPTION
As discussed in the issue #99, I've added a command line option to disable web security allowing content to be loaded via HTTP even if the target URL is HTTPS.