### PR TITLE
Rebind 'Copy Current URL' to 'CmdOrCtrl+L' to mimic 'Open Location'

### DIFF
--- a/app/src/components/menu/menu.js
+++ b/app/src/components/menu/menu.js
@@ -44,7 +44,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
                 },
                 {
                     label: 'Copy Current URL',
-                    accelerator: 'CmdOrCtrl+C',
+                    accelerator: 'CmdOrCtrl+L',
                     click: () => {
                         const currentURL = getCurrentUrl();
                         clipboard.writeText(currentURL);


### PR DESCRIPTION
I often need to copy the current webpage link to paste into other apps/windows/browsers, and the current bind was being overwritten by "Copy"