### PR TITLE
Add mnemonics to main menu items

### DIFF
--- a/app/src/components/menu/menu.js
+++ b/app/src/components/menu/menu.js
@@ -17,7 +17,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
 
     const template = [
         {
-            label: 'Edit',
+            label: '&Edit',
             submenu: [
                 {
                     label: 'Undo',
@@ -69,7 +69,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
             ]
         },
         {
-            label: 'View',
+            label: '&View',
             submenu: [
                 {
                     label: 'Back',
@@ -152,7 +152,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
             ]
         },
         {
-            label: 'Window',
+            label: '&Window',
             role: 'window',
             submenu: [
                 {
@@ -168,7 +168,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
             ]
         },
         {
-            label: 'Help',
+            label: '&Help',
             role: 'help',
             submenu: [
                 {
@@ -189,7 +189,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
 
     if (process.platform === 'darwin') {
         template.unshift({
-            label: 'Electron',
+            label: '&Electron',
             submenu: [
                 {
                     label: 'Services',

--- a/app/src/components/menu/menu.js
+++ b/app/src/components/menu/menu.js
@@ -189,7 +189,7 @@ function createMenu({nativefierVersion, appQuit, zoomIn, zoomOut, goBack, goForw
 
     if (process.platform === 'darwin') {
         template.unshift({
-            label: '&Electron',
+            label: 'E&lectron',
             submenu: [
                 {
                     label: 'Services',


### PR DESCRIPTION
This will allow users to open main menu items with Alt keys

example: Alt+W will open Window menu, Alt+E will open Edit menu

This way you can navigate on the menu with keyboard only.