### PR TITLE
Update version of electron-packager to fix security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-polyfill": "^6.7.2",
     "cheerio": "^0.19.0",
     "commander": "^2.9.0",
-    "electron-packager": "^5.2.1",
+    "electron-packager": "^7.0.1",
     "gitcloud": "^0.1.0",
     "hasbin": "^1.2.0",
     "lodash": "^4.0.0",


### PR DESCRIPTION
There is a security issue with the version of electron we are currently using. It has been fixed but we never updated our dependencies to use the latest patched version. See issue #193 for more details