### PR TITLE
Revert "Fix FOUC with inject CSS files"

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -125,7 +125,7 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
         mainWindow.webContents.setUserAgent(options.userAgent);
     }
 
-    mainWindow.webContents.on('did-get-response-details', () => {
+    mainWindow.webContents.on('did-finish-load', () => {
         mainWindow.webContents.send('params', JSON.stringify(options));
         mainWindow.webContents.insertCSS(getCssToInject());
     });


### PR DESCRIPTION
This reverts commit eeb661b6cd82a3f21f5adbf0d1389cf2804fd16b.

fixes #191 

This was causing injected CSS to pile up over and over each time javascript did an HTTP request, which resulted in massive slowdown over time.  For sites that do a lot of HTTP requests (example: hangouts during a call), things can get unbearably slow very quickly and CPU usage hits 100% until you reload with ctrl-R.

I'm not sure how to fix the flash of unstyled content (FOUC) fixed by eeb661b6cd8 but I haven't had that issue.