### PR TITLE
Fix internal link detection

### DIFF
--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -18,8 +18,8 @@ function isWindows() {
 }
 
 function linkIsInternal(currentUrl, newUrl) {
-    var currentDomain = wurl('domain', currentUrl);
-    var newDomain = wurl('domain', newUrl);
+    var currentDomain = wurl('sub', currentUrl) + wurl('domain', currentUrl);
+    var newDomain = wurl('sub', newUrl) + wurl('domain', newUrl);
     return currentDomain === newDomain;
 }
 


### PR DESCRIPTION
Links that point to internal sites on a different subdomain from hosted app are currently considered 'internal' links because the root domain (as returned by wurl) is the same. 

This change makes sure the subdomain is considered. Downside is that foo.bar.com will be considered different from bar.com - which is what should happen technically, though not practically. Maybe this should be a flag?