### PR TITLE
Fix/performance issues with FOUC

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -6,7 +6,7 @@ import helpers from './../../helpers/helpers';
 import createMenu from './../menu/menu';
 import initContextMenu from './../contextMenu/contextMenu';
 
-const {isOSX, linkIsInternal, getCssToInject, shouldInjectCss} = helpers;
+const {isOSX, linkIsInternal, getCssToInject, shouldInjectCss, debugLog} = helpers;
 
 const ZOOM_INTERVAL = 0.1;
 
@@ -131,6 +131,7 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
 
     maybeInjectCss(mainWindow);
     mainWindow.webContents.on('did-finish-load', () => {
+        debugLog(mainWindow, 'did-finish-load');
         mainWindow.webContents.send('params', JSON.stringify(options));
     });
 
@@ -206,16 +207,19 @@ function maybeInjectCss(browserWindow) {
     const cssToInject = getCssToInject();
 
     const injectCss = () => {
+        debugLog(browserWindow, 'Injecting css');
         browserWindow.webContents.insertCSS(cssToInject);
     };
 
     browserWindow.webContents.on('did-finish-load', () => {
+        debugLog(browserWindow, 'did finish load, css');
         // remove the injection of css the moment the page is loaded
         browserWindow.webContents.removeListener('did-get-response-details', injectCss);
     });
 
     // on every page navigation inject the css
     browserWindow.webContents.on('did-navigate', () => {
+        debugLog(browserWindow, 'did navigate');
         // we have to inject the css in did-get-response-details to prevent the fouc
         // will run multiple times
         browserWindow.webContents.on('did-get-response-details', injectCss);

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -6,7 +6,7 @@ import helpers from './../../helpers/helpers';
 import createMenu from './../menu/menu';
 import initContextMenu from './../contextMenu/contextMenu';
 
-const {isOSX, linkIsInternal, getCssToInject, shouldInjectCss, debugLog} = helpers;
+const {isOSX, linkIsInternal, getCssToInject, shouldInjectCss} = helpers;
 
 const ZOOM_INTERVAL = 0.1;
 
@@ -131,7 +131,6 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
 
     maybeInjectCss(mainWindow);
     mainWindow.webContents.on('did-finish-load', () => {
-        debugLog(mainWindow, 'did-finish-load');
         mainWindow.webContents.send('params', JSON.stringify(options));
     });
 
@@ -207,19 +206,16 @@ function maybeInjectCss(browserWindow) {
     const cssToInject = getCssToInject();
 
     const injectCss = () => {
-        debugLog(browserWindow, 'Injecting css');
         browserWindow.webContents.insertCSS(cssToInject);
     };
 
     browserWindow.webContents.on('did-finish-load', () => {
-        debugLog(browserWindow, 'did finish load, css');
         // remove the injection of css the moment the page is loaded
         browserWindow.webContents.removeListener('did-get-response-details', injectCss);
     });
 
     // on every page navigation inject the css
     browserWindow.webContents.on('did-navigate', () => {
-        debugLog(browserWindow, 'did navigate');
         // we have to inject the css in did-get-response-details to prevent the fouc
         // will run multiple times
         browserWindow.webContents.on('did-get-response-details', injectCss);

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -23,11 +23,16 @@ function linkIsInternal(currentUrl, newUrl) {
     return currentDomain === newDomain;
 }
 
-function getCssToInject() {
-    const needToInject = fs.existsSync(INJECT_CSS_PATH);
-    if (!needToInject) {
-        return '';
+function shouldInjectCss() {
+    try {
+        fs.accessSync(INJECT_CSS_PATH, fs.F_OK);
+        return true;
+    } catch (e) {
+        return false;
     }
+}
+
+function getCssToInject() {
     return fs.readFileSync(INJECT_CSS_PATH).toString();
 }
 
@@ -49,5 +54,7 @@ export default {
     isLinux,
     isWindows,
     linkIsInternal,
-    getCssToInject
+    getCssToInject,
+    debugLog,
+    shouldInjectCss
 };

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -31,6 +31,19 @@ function getCssToInject() {
     return fs.readFileSync(INJECT_CSS_PATH).toString();
 }
 
+/**
+ * Helper method to print debug messages from the main process in the browser window
+ * @param {BrowserWindow} browserWindow
+ * @param message
+ */
+function debugLog(browserWindow, message) {
+    // need the timeout as it takes time for the preload javascript to be loaded in the window
+    setTimeout(() => {
+        browserWindow.webContents.send('debug', message);
+    }, 3000);
+    console.log(message);
+}
+
 export default {
     isOSX,
     isLinux,

--- a/app/src/static/preload.js
+++ b/app/src/static/preload.js
@@ -37,6 +37,10 @@ ipcRenderer.on('params', (event, message) => {
     console.log('nativefier.json', appArgs);
 });
 
+ipcRenderer.on('debug', (event, message) => {
+    console.log('debug:', message);
+});
+
 ipcRenderer.on('change-zoom', (event, message) => {
     webFrame.setZoomFactor(message);
 });


### PR DESCRIPTION
Fixes #191 

- Use `did-navigate` instead of `did-start-loading` to trigger the injection of css on every page. This is because Electron somehow triggers a `did-start-loading` event on ajax events without having a `did-finish-load` event to indicate completion even after `did-finish-load` has triggered on a page, which will cause the injection of css through `did-get-response-details` to continue indefinitely on every ajax request. Take note that to avoid the flash of unstyled content, the current behaviour of injecting css on `did-get-response-details` is maintained, which triggers many times until `did-finish-load`. This runs ~50 times or so on loading the YouTube home page, but it does not appear to affect performance because the injection of css stops the moment `did-finish-load` triggers.
- Perform injection of css in a separate function that returns immediately and does not set the mainWindow callback events if there is no css to be injected
- Cache the css to be injected so we only do file i/o once
- Use `fs.accessSync` instead of the deprecated `fs.existsSync` to determine if css should be injected