### PR TITLE
remove all non ascii or use default app name

### DIFF
--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -154,8 +154,8 @@ function optionsFactory(inpOptions, callback) {
 
 function sanitizeFilename(str) {
     const cleaned = sanitizeFilenameLib(str);
-    // remove all non ascii or do nothing
-    return cleaned.replace(/[^\x00-\x7F]/g, '') || cleaned;
+    // remove all non ascii or use default app name
+    return cleaned.replace(/[^\x00-\x7F]/g, '') || DEFAULT_APP_NAME;
 }
 
 function sanitizeOptions(options) {

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -154,8 +154,8 @@ function optionsFactory(inpOptions, callback) {
 
 function sanitizeFilename(str) {
     const cleaned = sanitizeFilenameLib(str);
-    // remove all non ascii
-    return cleaned.replace(/[^\x00-\x7F]/g, '');
+    // remove all non ascii or do nothing
+    return cleaned.replace(/[^\x00-\x7F]/g, '') || cleaned;
 }
 
 function sanitizeOptions(options) {

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -154,8 +154,8 @@ function optionsFactory(inpOptions, callback) {
 
 function sanitizeFilename(str) {
     const cleaned = sanitizeFilenameLib(str);
-    // remove non ascii
-    return cleaned.replace(/[^\x00-\x7F]/, '');
+    // remove all non ascii
+    return cleaned.replace(/[^\x00-\x7F]/g, '');
 }
 
 function sanitizeOptions(options) {


### PR DESCRIPTION
the sanitizeFilename function only remove one none ascii char

![image](https://cloud.githubusercontent.com/assets/1452677/16188017/0588562e-3706-11e6-97de-641c06696e3e.png)

![image](https://cloud.githubusercontent.com/assets/1452677/16188029/1a339d86-3706-11e6-9958-2a446177e05f.png)

The exe name should be "微信网页版.exe", not "信网页版.exe".
