### PR TITLE
Added a --zoom option for setting default zoom

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -42,7 +42,8 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
             // node globals causes problems with sites like messenger.com
             nodeIntegration: false,
             webSecurity: !options.insecure,
-            preload: path.join(__dirname, 'static', 'preload.js')
+            preload: path.join(__dirname, 'static', 'preload.js'),
+            zoomFactor: options.zoom
         },
         // after webpack path here should reference `resources/app/`
         icon: path.join(__dirname, '../', '/icon.png'),

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,6 +35,7 @@
     - [[verbose]](#verbose)
     - [[disable-context-menu]](#disable-context-menu)
     - [[disable-dev-tools]](#disable-dev-tools)
+    - [[zoom]](#zoom)
 - [Programmatic API](#programmatic-api)
 
 ## Command Line
@@ -327,6 +328,14 @@ Disable the context menu
 
 Disable the Chrome developer tools
 
+#### [zoom]
+
+```
+--zoom <value>
+```
+
+Sets a default zoom factor to be used when the app is opened, defaults to `1.0`.
+
 ## Programmatic API
 
 You can use the Nativefier programmatic API as well.
@@ -360,7 +369,8 @@ var options = {
     userAgent: 'Mozilla ...', // will infer a default for your current system
     ignoreCertificate: false,
     insecure: false,
-    honest: false
+    honest: false,
+    zoom: 1.0
 };
 
 nativefier(options, function(error, appPath) {

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -114,7 +114,8 @@ function selectAppArgs(options) {
         hideWindowFrame: options.hideWindowFrame,
         maximize: options.maximize,
         disableContextMenu: options.disableContextMenu,
-        disableDevTools: options.disableDevTools
+        disableDevTools: options.disableDevTools,
+        zoom: options.zoom
     };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -50,6 +50,7 @@ if (require.main === module) {
         .option('--verbose', 'if verbose logs should be displayed')
         .option('--disable-context-menu', 'disable the context menu')
         .option('--disable-dev-tools', 'disable developer tools')
+        .option('--zoom <value>', 'default zoom factor to use when the app is opened, defaults to 1.0', parseFloat)
         .parse(process.argv);
 
     if (!process.argv.slice(2).length) {

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -65,7 +65,8 @@ function optionsFactory(inpOptions, callback) {
         disableContextMenu: inpOptions.disableContextMenu,
         disableDevTools: inpOptions.disableDevTools,
         // workaround for electron-packager#375
-        tmpdir: false
+        tmpdir: false,
+        zoom: inpOptions.zoom || 1.0
     };
 
     if (options.verbose) {


### PR DESCRIPTION
These changes add the ability to declare a default zoom factor for an application with the `--zoom` flag. While it doesn't fix #125 directly, it at least seems like a better workaround than the one mentioned in the issue.