### PR TITLE
Added support for app-copyright, app-version and version-string

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,9 @@
     - [[disable-context-menu]](#disable-context-menu)
     - [[disable-dev-tools]](#disable-dev-tools)
     - [[zoom]](#zoom)
+    - [[app-copyright]](#app-copyright)
+    - [[app-version]](#app-version)
+
 - [Programmatic API](#programmatic-api)
 
 ## Command Line
@@ -335,6 +338,22 @@ Disable the Chrome developer tools
 ```
 
 Sets a default zoom factor to be used when the app is opened, defaults to `1.0`.
+
+#### [app-copyright]
+
+```
+--app-copyright
+```
+
+Maps to `LegalCopyright` metadata property on Windows and `NSumanReadableCopyright` on macOS.
+
+#### [app-version]
+
+```
+--app-version
+```
+
+Maps to the `ProductVersion` metadata property on Windows and `CFBundleShortVersionString` on macOS.
 
 ## Programmatic API
 

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -117,7 +117,6 @@ function selectAppArgs(options) {
         maximize: options.maximize,
         disableContextMenu: options.disableContextMenu,
         disableDevTools: options.disableDevTools,
-        'version-string': options['version-string'],
         zoom: options.zoom
     };
 }

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -90,7 +90,7 @@ function changeAppPackageJsonName(appPath, name, url) {
 /**
  * Only picks certain app args to pass to nativefier.json
  * @param options
- * @returns {{app-copyright: (*|string), app-version: (*|string), name: (*|string), targetUrl: (string|*), counter: *, width: *, height: *, showMenuBar: *, userAgent: *, nativefierVersion: *, insecure: *, disableWebSecurity: *, version-string: (object|*)}}
+ * @returns {{app-copyright: (*|string), app-version: (*|string), name: (*|string), targetUrl: (string|*), counter: *, width: *, height: *, showMenuBar: *, userAgent: *, nativefierVersion: *, insecure: *, disableWebSecurity: *}}
  */
 function selectAppArgs(options) {
     return {

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -90,10 +90,12 @@ function changeAppPackageJsonName(appPath, name, url) {
 /**
  * Only picks certain app args to pass to nativefier.json
  * @param options
- * @returns {{name: (*|string), targetUrl: (string|*), counter: *, width: *, height: *, showMenuBar: *, userAgent: *, nativefierVersion: *, insecure: *, disableWebSecurity: *}}
+ * @returns {{app-copyright: (*|string), app-version: (*|string), name: (*|string), targetUrl: (string|*), counter: *, width: *, height: *, showMenuBar: *, userAgent: *, nativefierVersion: *, insecure: *, disableWebSecurity: *, version-string: (object|*)}}
  */
 function selectAppArgs(options) {
     return {
+        'app-copyright': options['app-copyright'],
+        'app-version': options['app-version'],
         name: options.name,
         targetUrl: options.targetUrl,
         counter: options.counter,
@@ -115,6 +117,7 @@ function selectAppArgs(options) {
         maximize: options.maximize,
         disableContextMenu: options.disableContextMenu,
         disableDevTools: options.disableDevTools,
+        'version-string': options['version-string'],
         zoom: options.zoom
     };
 }

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -32,6 +32,8 @@ const DEFAULT_APP_NAME = 'APP';
 function optionsFactory(inpOptions, callback) {
 
     const options = {
+        'app-copyright': inpOptions['app-copyright'],
+        'app-version': inpOptions['app-version'],
         dir: PLACEHOLDER_APP_DIR,
         name: inpOptions.name,
         targetUrl: normalizeUrl(inpOptions.targetUrl),
@@ -66,6 +68,7 @@ function optionsFactory(inpOptions, callback) {
         disableDevTools: inpOptions.disableDevTools,
         // workaround for electron-packager#375
         tmpdir: false,
+        'version-string': inpOptions['version-string'],
         zoom: inpOptions.zoom || 1.0
     };
 

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -32,8 +32,8 @@ const DEFAULT_APP_NAME = 'APP';
 function optionsFactory(inpOptions, callback) {
 
     const options = {
-        'app-copyright': inpOptions['app-copyright'],
-        'app-version': inpOptions['app-version'],
+        appCopyright: inpOptions.appCopyright,
+        appVersion: inpOptions.appVersion,
         dir: PLACEHOLDER_APP_DIR,
         name: inpOptions.name,
         targetUrl: normalizeUrl(inpOptions.targetUrl),
@@ -68,7 +68,7 @@ function optionsFactory(inpOptions, callback) {
         disableDevTools: inpOptions.disableDevTools,
         // workaround for electron-packager#375
         tmpdir: false,
-        'version-string': inpOptions['version-string'],
+        versionString: inpOptions.versionString,
         zoom: inpOptions.zoom || 1.0
     };
 

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -68,7 +68,6 @@ function optionsFactory(inpOptions, callback) {
         disableDevTools: inpOptions.disableDevTools,
         // workaround for electron-packager#375
         tmpdir: false,
-        versionString: inpOptions.versionString,
         zoom: inpOptions.zoom || 1.0
     };
 


### PR DESCRIPTION
_See #226._
- Used the same keys like [electron-packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md) (`'app-version'` instead of `appVersion`).
- Currently only support the [Nativefier programmatic API](https://github.com/jiahaog/nativefier/blob/development/docs/api.md#programmatic-api)
