### PR TITLE
add "copy link location" and "--internal-urls <regex>" features

### DIFF
--- a/app/src/components/contextMenu/contextMenu.js
+++ b/app/src/components/contextMenu/contextMenu.js
@@ -1,4 +1,4 @@
-import {Menu, ipcMain, shell, BrowserWindow} from 'electron';
+import {Menu, ipcMain, shell, clipboard, BrowserWindow} from 'electron';
 
 function initContextMenu(mainWindow) {
     ipcMain.on('contextMenuOpened', (event, targetHref) => {
@@ -17,6 +17,18 @@ function initContextMenu(mainWindow) {
                 click: () => {
                     if (targetHref) {
                         new BrowserWindow().loadURL(targetHref);
+                        return;
+                    }
+
+                    mainWindow.useDefaultWindowBehaviour = true;
+                    mainWindow.webContents.send('contextMenuClosed');
+                }
+            },
+            {
+                label: 'Copy link location',
+                click: () => {
+                    if (targetHref) {
+                        clipboard.writeText(targetHref);
                         return;
                     }
 

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -159,7 +159,7 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
             return;
         }
 
-        if (linkIsInternal(options.targetUrl, urlToGo)) {
+        if (linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
             return;
         }
         event.preventDefault();

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -17,10 +17,15 @@ function isWindows() {
     return os.platform() === 'win32';
 }
 
-function linkIsInternal(currentUrl, newUrl) {
-    var currentDomain = wurl('domain', currentUrl);
-    var newDomain = wurl('domain', newUrl);
-    return currentDomain === newDomain;
+function linkIsInternal(currentUrl, newUrl, internalUrlRegex) {
+    if (internalUrlRegex) {
+        var regex = RegExp(internalUrlRegex);
+        return regex.test(newUrl);
+    } else {
+        var currentDomain = wurl('domain', currentUrl);
+        var newDomain = wurl('domain', newUrl);
+        return currentDomain === newDomain;
+    }
 }
 
 function shouldInjectCss() {

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -21,11 +21,11 @@ function linkIsInternal(currentUrl, newUrl, internalUrlRegex) {
     if (internalUrlRegex) {
         var regex = RegExp(internalUrlRegex);
         return regex.test(newUrl);
-    } else {
-        var currentDomain = wurl('domain', currentUrl);
-        var newDomain = wurl('domain', newUrl);
-        return currentDomain === newDomain;
     }
+
+    var currentDomain = wurl('domain', currentUrl);
+    var newDomain = wurl('domain', newUrl);
+    return currentDomain === newDomain;
 }
 
 function shouldInjectCss() {

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -115,7 +115,8 @@ function selectAppArgs(options) {
         maximize: options.maximize,
         disableContextMenu: options.disableContextMenu,
         disableDevTools: options.disableDevTools,
-        zoom: options.zoom
+        zoom: options.zoom,
+        internalUrls: options.internalUrls
     };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,6 +51,7 @@ if (require.main === module) {
         .option('--disable-context-menu', 'disable the context menu')
         .option('--disable-dev-tools', 'disable developer tools')
         .option('--zoom <value>', 'default zoom factor to use when the app is opened, defaults to 1.0', parseFloat)
+        .option('--internal-urls <value>', 'regular expression of URLs to consider "internal"; all other URLs will be opened in an external browser.  (default: URLs on same second-level domain as app)')
         .parse(process.argv);
 
     if (!process.argv.slice(2).length) {

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -66,7 +66,8 @@ function optionsFactory(inpOptions, callback) {
         disableDevTools: inpOptions.disableDevTools,
         // workaround for electron-packager#375
         tmpdir: false,
-        zoom: inpOptions.zoom || 1.0
+        zoom: inpOptions.zoom || 1.0,
+        internalUrls: inpOptions.internalUrls || null
     };
 
     if (options.verbose) {


### PR DESCRIPTION
Two mostly unrelated features -- let me know if these should be separate PRs.

* "copy link location" for context menu -- kept meaning to add this and finally got around to it
* "--internal-urls <regex>" argument to override the default method used to determine which URLs should stay in the nativefied app.  In google inbox, for example, I want google docs to open in my main browser.  Regex gives the user a lot of flexibility.