### PR TITLE
Fix #226 - Added support for app-copyright, app-version, build-version, version-string and win32metadata

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -100,6 +100,30 @@ The alternative values `win32` (for Windows) or `darwin`, `mac` (for OSX) can al
 
 Processor architecture, automatically determined based on the current OS. Can be overwritten by specifying either `ia32`, `x64` or `armv7l`.
 
+#### [app-copyright]
+
+```
+--app-copyright <value>
+```
+
+The human-readable copyright line for the app. Maps to the `LegalCopyright` metadata property on Windows, and `NSHumanReadableCopyright` on OS X.
+
+#### [app-version]
+
+```
+--app-version <value>
+```
+
+The release version of the application. By default the `version` property in the `package.json` is used but it can be overridden with this argument. If neither are provided, the version of Electron will be used. Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.
+
+#### [build-version]
+
+```
+--build-version <value>
+```
+
+The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.
+
 #### [electron-version]
 
 ```
@@ -431,6 +455,55 @@ nativefier(options, function(error, appPath) {
     }
     console.log('App has been nativefied to', appPath);
 });
+```
+
+### Addition packaging options for Windows
+
+#### [version-string]
+
+*Object* (**deprecated** and will be removed in a future major version (of `electron-packager`), please use the
+[`win32metadata`](#win32metadata) parameter instead)
+
+#### [win32metadata]
+
+```
+--win32metadata <json-string>
+```
+
+a JSON string of key/value pairs of application metadata (ProductName, InternalName, FileDescription) to embed into the executable (Windows only).
+
+Example:
+
+```bash
+nativefier <your-geolocation-enabled-website> --win32metadata '{"ProductName": "Your Product Name", "InternalName", "Your Internal Name", "FileDescription": "Your File Description"}'
+```
+
+##### Programmatic API
+
+*Object*
+
+Object (also known as a "hash") of application metadata to embed into the executable:
+- `CompanyName`
+- `FileDescription`
+- `OriginalFilename`
+- `ProductName`
+- `InternalName`
+
+_(Note that `win32metadata` was added to `electron-packager` in version 8.0.0)_
+
+In your `.js` file:
+
+```javascript
+var options = {
+    ...
+    win32metadata: {
+      CompanyName: 'Your Company Name',
+      FileDescription: 'Your File Description',
+      OriginalFilename: 'Your Original Filename',
+      ProductName: 'Your Product Name',
+      InternalName: 'Your Internal Name'
+    }
+};
 ```
 
 More description about the options for `nativefier` can be found at the above [section](#command-line).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "dev-up": "npm install && (cd app && npm install) && npm run build",
+    "dev-up": "npm install && (cd ./app && npm install) && npm run build",
     "test": "jest && gulp test",
     "jest": "jest",
     "tdd": "gulp tdd",

--- a/src/build/buildMain.js
+++ b/src/build/buildMain.js
@@ -77,6 +77,66 @@ function maybeCopyIcons(options, appPath, callback) {
   });
 }
 
+/**
+ * Removes invalid parameters from options if building for Windows while not on Windows
+ * and Wine is not installed
+ * @param options
+ */
+function removeInvalidOptions(options, param) {
+  const packageOptions = JSON.parse(JSON.stringify(options));
+  if (options.platform === 'win32' && !isWindows()) {
+    if (!hasBinary.sync('wine')) {
+      log.warn(`Wine is required to use "${param}" option for a Windows app when packaging on non-windows platforms`);
+      packageOptions[param] = null;
+    }
+  }
+  return packageOptions;
+}
+
+/**
+ * Removes the `app-copyright` parameter from options if building for Windows while not on Windows
+ * and Wine is not installed
+ * @param options
+ */
+function maybeNoAppCopyrightOption(options) {
+  return removeInvalidOptions(options, 'app-copyright');
+}
+
+/**
+ * Removes the `build-version` parameter from options if building for Windows while not on Windows
+ * and Wine is not installed
+ * @param options
+ */
+function maybeNoBuildVersionOption(options) {
+  return removeInvalidOptions(options, 'build-version');
+}
+
+/**
+ * Removes the `app-version` parameter from options if building for Windows while not on Windows
+ * and Wine is not installed
+ * @param options
+ */
+function maybeNoAppVersionOption(options) {
+  return removeInvalidOptions(options, 'app-version');
+}
+
+/**
+ * Removes the `version-string` parameter from options if building for Windows while not on Windows
+ * and Wine is not installed
+ * @param options
+ */
+function maybeNoVersionStringOption(options) {
+  return removeInvalidOptions(options, 'version-string');
+}
+
+/**
+ * Removes the `win32metadata` parameter from options if building for Windows while not on Windows
+ * and Wine is not installed
+ * @param options
+ */
+function maybeNoWin32metadataOption(options) {
+  return removeInvalidOptions(options, 'win32metadata');
+}
 
 /**
  * @callback buildAppCallback
@@ -133,7 +193,13 @@ function buildMain(inpOptions, callback) {
     (options, callback) => {
       progress.tick('packaging');
       // maybe skip passing icon parameter to electron packager
-      const packageOptions = maybeNoIconOption(options);
+      let packageOptions = maybeNoIconOption(options);
+      // maybe skip passing other parameters to electron packager
+      packageOptions = maybeNoAppCopyrightOption(packageOptions);
+      packageOptions = maybeNoAppVersionOption(packageOptions);
+      packageOptions = maybeNoBuildVersionOption(packageOptions);
+      packageOptions = maybeNoVersionStringOption(packageOptions);
+      packageOptions = maybeNoWin32metadataOption(packageOptions);
 
       packagerConsole.override();
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,11 @@ function collect(val, memo) {
   return memo;
 }
 
+function parseJson(val) {
+  if (!val) return {};
+  return JSON.parse(val);
+}
+
 if (require.main === module) {
   program
     .version(packageJson.version)
@@ -22,6 +27,10 @@ if (require.main === module) {
     .option('-n, --name <value>', 'app name')
     .option('-p, --platform <value>', '\'osx\', \'linux\' or \'windows\'')
     .option('-a, --arch <value>', '\'ia32\' or \'x64\' or \'armv7l\'')
+    .option('--app-version <value>', 'The release version of the application.  Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.')
+    .option('--build-version <value>', 'The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.')
+    .option('--app-copyright <value>', 'The human-readable copyright line for the app. Maps to the `LegalCopyright` metadata property on Windows, and `NSHumanReadableCopyright` on OS X')
+    .option('--win32metadata <json-string>', 'a JSON string of key/value pairs of application metadata (ProductName, InternalName, FileDescription) to embed into the executable (Windows only).', parseJson)
     .option('-e, --electron-version <value>', 'electron version to package, without the \'v\', see https://github.com/atom/electron/releases')
     .option('--no-overwrite', 'do not override output directory if it already exists, defaults to false')
     .option('-c, --conceal', 'packages the source code within your app into an archive, defaults to false, see http://electron.atom.io/docs/v0.36.0/tutorial/application-packaging/')

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -17,7 +17,11 @@ export default function (inpOptions) {
   const options = {
     dir: PLACEHOLDER_APP_DIR,
     name: inpOptions.name,
-    win32metadata: {
+    'app-version': inpOptions.appVersion,
+    'build-version': inpOptions.buildVersion,
+    'app-copyright': inpOptions.appCopyright,
+    'version-string': inpOptions.versionString,
+    win32metadata: inpOptions.win32metadata || {
       ProductName: inpOptions.name,
       InternalName: inpOptions.name,
       FileDescription: inpOptions.name,


### PR DESCRIPTION
See Issue https://github.com/jiahaog/nativefier/issues/226.

Added support for `app-copyright`, `app-version`, `build-version`, `version-string` and `win32metadata`.

Similar to PR https://github.com/jiahaog/nativefier/pull/228, but I also needed `build-version`.  I also included support for `win32metadata` since that was recently added to `electron-packager` (v8.0.0) making `version-string` deprecated.

`app-copyright`, `app-version`, `build-version` are supported in the CLI but `version-string` and `win32metadata` only supported via the [Nativefier Programmatic API](https://github.com/jiahaog/nativefier/blob/development/docs/api.md#programmatic-api).
