### PR TITLE
Fix counter notifications

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -136,20 +136,24 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
     });
 
     if (options.counter) {
-        mainWindow.on('page-title-updated', () => {
-            if (mainWindow.isFocused()) {
+        mainWindow.on('page-title-updated', (e, title) => {
+            const itemCountRegex = /[\(\[{](\d*?)[}\]\)]/;
+            const match = itemCountRegex.exec(title);
+            if (match) {
+                setDockBadge(match[1]);
+            } else {
+                setDockBadge('');
+            }
+        });
+    } else {
+        ipcMain.on('notification', () => {
+            if (!isOSX() || mainWindow.isFocused()) {
                 return;
             }
-
-            if (options.counter) {
-                const itemCountRegex = /[\(\[{](\d*?)[}\]\)]/;
-                const match = itemCountRegex.exec(mainWindow.getTitle());
-                if (match) {
-                    setDockBadge(match[1]);
-                }
-                return;
-            }
-            setDockBadge('●');
+            setDockBadge('•');
+        });
+        mainWindow.on('focus', () => {
+            setDockBadge('');
         });
     }
 
@@ -167,10 +171,6 @@ function createMainWindow(options, onAppQuit, setDockBadge) {
     });
 
     mainWindow.loadURL(options.targetUrl);
-
-    mainWindow.on('focus', () => {
-        setDockBadge('');
-    });
 
     mainWindow.on('close', event => {
         if (mainWindow.isFullScreen()) {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,7 +1,7 @@
 import 'source-map-support/register';
 import fs from 'fs';
 import path from 'path';
-import {app, ipcMain} from 'electron';
+import {app} from 'electron';
 import createLoginWindow from './components/login/loginWindow';
 import createMainWindow from './components/mainWindow/mainWindow';
 import helpers from './helpers/helpers';
@@ -70,11 +70,4 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
     // for http authentication
     event.preventDefault();
     createLoginWindow(callback);
-});
-
-ipcMain.on('notification', () => {
-    if (!isOSX() || mainWindow.isFocused()) {
-        return;
-    }
-    setDockBadge('●');
 });


### PR DESCRIPTION
This refactors and improves on the badge notification setup. I've centralized and streamlined the logic for badge behavior all to a single if/else block in `createMainWindow`, so that it is easier to reason about as a whole. I believe the intended behavior is as follows:

- When using the `counter` option, a numbered badge should appear on the app icon corresponding to the window title, whether focused or not. If no number can be parsed, then no badge should appear.
- When not using the `counter` option, the `•` badge should appear when a notification is sent, and should clear when the app is focused. (I made a slight tweak to use the smaller `•` instead of `●`, which looks a bit more native to my eye.)

Along the way, I fixed the `page-title-updated` listener to use the `title` argument instead of `mainWindow.getTitle()`, which incorrectly was retrieving the title before the change happened. It seems like the electron event should be named `page-title-will-update` instead. /shrug