### PR TITLE
Fix context menu actions broken on <a> elements containing nested markup

### DIFF
--- a/app/src/static/preload.js
+++ b/app/src/static/preload.js
@@ -17,6 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('contextmenu', event => {
         event.preventDefault();
         const targetElement = event.srcElement;
+        
+        // the clicked element is the deepest in the DOM, and may not be the <a> bearing the href
+        // for example, <a href="..."><span>Google</span></a>
+        while (!targetElement.href && targetElement.parentElement) {
+            targetElement = targetElement.parentElement;
+        }
         const targetHref = targetElement.href;
 
         if (!targetHref) {


### PR DESCRIPTION
Test case: open nativefier on

```html
<!DOCTYPE html>
<html>
<head>
  <meta charset="utf-8">
  <title>Test</title>
</head>
<body>
  <a href="https://google.com/">Google</a>
  <br>
  <a href="https://google.com/"><span>Google, in span</span></a>
</body>
</html>
```

and try to `Right Click` → `Open in Default Browser` both links.

* **Expected**: both links open in default browser
* **Actual under nativefier 7.0.1**: Nothing happens when clicking the second link in which the `<a>` contains a `<span>`