### PR TITLE
Remove dependency on imagemagick for OSX icon conversion

### DIFF
--- a/bin/convertToIcns
+++ b/bin/convertToIcns
@@ -7,18 +7,82 @@
 # ./convertToIcns ~/sample.png ~/Desktop/converted.icns
 
 # exit the shell script on error immediately
+
 set -e
 
-# import script as variable
-CONVERT_TO_PNG="${BASH_SOURCE%/*}/convertToPng"
+make_icns_sips() {
+    local file output_file iconset output_icon
+    file="${1}"
+    output_file="${2}"
+    iconset="$(mktemp -d)"
+    output_icon="$(mktemp).icns"
+
+    for size in {16,32,64,128,256,512}; do
+        sips --setProperty format png --resampleHeightWidth "${size}" "${size}" "${file}" --out "${iconset}/icon_${size}x${size}.png" &> /dev/null
+        sips --setProperty format png --resampleHeightWidth "$((size * 2))" "$((size * 2))" "${file}" --out "${iconset}/icon_${size}x${size}@2x.png" &> /dev/null
+    done
+
+    mv "${iconset}" "${iconset}.iconset"
+    iconutil --convert icns "${iconset}.iconset" --output "${output_icon}"
+
+    if [[ -z "${output_file}" ]]; then
+        echo "${output_icon}" # so its path is returned when the function ends
+    else
+        mv "${output_icon}" "${output_file}"
+    fi
+
+    # clean up
+    rm -rf "${iconset}"
+}
+
+make_icns_imagemagick() {
+    local SOURCE DEST CONVERT_TO_PNG TEMP_DIR ICONSET
+    SOURCE="${1}"
+    DEST="${2}"
+    # import script as variable
+    CONVERT_TO_PNG="${BASH_SOURCE%/*}/convertToPng"
+    TEMP_DIR="$(mktemp -d)"
+    ICONSET="$(mktemp -d)"
+
+    PNG_PATH="${TEMP_DIR}/icon.png"
+    ${CONVERT_TO_PNG} "${SOURCE}" "${PNG_PATH}"
+
+    # Resample image into iconset
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 16x16 "${ICONSET}/icon_16x16.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_16x16@2x.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_32x32.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 64x64 "${ICONSET}/icon_32x32@2x.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 128x128 "${ICONSET}/icon_128x128.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_128x128@2x.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_256x256.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_256x256@2x.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_512x512.png"
+    convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 1024x1024 "${ICONSET}/icon_512x512@2x.png"
+
+    # Create an icns file lefrom the iconset
+    mv "${ICONSET}" "${ICONSET}.iconset" && ICONSET="${ICONSET}.iconset"
+    iconutil -c icns "${ICONSET}" -o "${DEST}"
+
+    # clean up
+    rm -rf "${TEMP_DIR}" "${ICONSET}"
+}
+
 
 # Exec Paths
-type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
-type iconutil >/dev/null 2>&1 || { echo >&2 "Cannot find required iconutil executable"; exit 1; }
+HAVE_IMAGEMAGICK=
+HAVE_ICONUTIL=
+HAVE_SIPS=
+
+type convert &>/dev/null && HAVE_IMAGEMAGICK=true
+type iconutil &>/dev/null && HAVE_ICONUTIL=true
+type sips &>/dev/null && HAVE_SIPS=true
+
+[[ -z "$HAVE_ICONUTIL" ]] && { echo >&2 "Cannot find required iconutil executable"; exit 1; }
+[[ -z "$HAVE_IMAGEMAGICK" && -z "$HAVE_SIPS" ]] && { echo >&2 "Cannot find required image converter, please install sips or imagemagick"; exit 1; }
 
 # Parameters
-SOURCE=$1
-DEST=$2
+SOURCE="$1"
+DEST="$2"
 
 # Check source and destination arguments
 if [ -z "${SOURCE}" ]; then
@@ -31,40 +95,11 @@ if [ -z "${DEST}" ]; then
 	exit 1
 fi
 
-# File Infrastructure
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-BASE="${NAME%.*}"
-TEMP_DIR="temp_icon"
-ICONSET="${BASE}.iconset"
+HAVE_IMAGEMAGICK=
+if [[ -n "$HAVE_IMAGEMAGICK" ]]; then
+    make_icns_imagemagick "${SOURCE}" "${DEST}"
+else
+    make_icns_sips "${SOURCE}" "${DEST}"
+fi
 
-function cleanUp() {
-    rm -rf "${TEMP_DIR}"
-    rm -rf "${ICONSET}"
-}
 
-trap cleanUp EXIT
-
-mkdir -p "${TEMP_DIR}"
-mkdir -p "${ICONSET}"
-
-PNG_PATH="${TEMP_DIR}/icon.png"
-${CONVERT_TO_PNG} "${SOURCE}" "${PNG_PATH}"
-
-# Resample image into iconset
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 16x16 "${ICONSET}/icon_16x16.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_16x16@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_32x32.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 64x64 "${ICONSET}/icon_32x32@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 128x128 "${ICONSET}/icon_128x128.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_128x128@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_256x256.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_256x256@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_512x512.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 1024x1024 "${ICONSET}/icon_512x512@2x.png"
-
-# Create an icns file lefrom the iconset
-iconutil -c icns "${ICONSET}" -o "${DEST}"
-
-trap - EXIT
-cleanUp

--- a/bin/convertToPng
+++ b/bin/convertToPng
@@ -12,8 +12,8 @@ type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Con
 type identify >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Identify executable"; exit 1; }
 
 # Parameters
-SOURCE=$1
-DEST=$2
+SOURCE="$1"
+DEST="$2"
 
 # Check source and destination arguments
 if [ -z "${SOURCE}" ]; then
@@ -42,7 +42,7 @@ mkdir -p "${TEMP_DIR}"
 
 # check if .ico is a sequence
 # pipe into cat so no exit code is given for grep if no matches are found
-IS_ICO_SET="$(identify ${SOURCE} | grep -e "\w\.ico\[0" | cat )"
+IS_ICO_SET="$(identify "${SOURCE}" | grep -e "\w\.ico\[0" | cat )"
 
 convert "${SOURCE}" "${TEMP_DIR}/${BASE}.png"
 if [ "${IS_ICO_SET}" ]; then

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "babel-register": "^6.6.0",
     "chai": "^3.4.1",
     "del": "^2.2.0",
+    "electron-dl": "^1.8.0",
+    "electron-window-state": "^4.1.0",
     "eslint": "^2.10.2",
     "eslint-config-google": "^0.5.0",
     "gulp": "^3.9.0",
@@ -77,6 +79,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.5",
-    "webpack-stream": "^3.1.0"
+    "webpack-stream": "^3.1.0",
+    "wurl": "^2.1.0"
   }
 }


### PR DESCRIPTION
Use sips and tiff2icns instead. Most (all?) macs will have these tools installed already, and sips supports almost as wide a range of image formats as ImageMagick
