### PR TITLE
Absolute link to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Nativefier is a command line tool that allows you to easily create a desktop app
 
 I did this because I was tired of having to `⌘-tab` or `alt-tab` to my browser and then search through the numerous open tabs when I was using [Facebook Messenger](http://messenger.com) or [Whatsapp Web](http://web.whatsapp.com).
 
-View the changelog [here](docs/changelog.md).
+View the changelog [here](https://github.com/jiahaog/nativefier/blob/development/docs/changelog.md).
 
 [Relevant Hacker News Thread](https://news.ycombinator.com/item?id=10930718)
 


### PR DESCRIPTION
The link to the changelog on [npmjs.com](https://www.npmjs.com/package/nativefier) links to the master branch, which doesn't exist. Not sure if there's a better fix, but I swapped it for an absolute URL instead.
