### PR TITLE
Add --single-instance switch

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -81,3 +81,20 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
     event.preventDefault();
     createLoginWindow(callback);
 });
+
+if (appArgs.singleInstance) {
+    const shouldQuit = app.makeSingleInstance(() => {
+        // Someone tried to run a second instance, we should focus our window.
+        if (mainWindow) {
+            if (mainWindow.isMinimized()) {
+                mainWindow.restore();
+            }
+            mainWindow.focus();
+
+        }
+    });
+
+    if (shouldQuit) {
+        app.quit();
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,7 @@
     - [[disable-dev-tools]](#disable-dev-tools)
     - [[zoom]](#zoom)
     - [[crash-reporter]](#crash-reporter)
+    - [[single-instance]](#single-instance)
 - [Programmatic API](#programmatic-api)
 
 ## Command Line
@@ -351,6 +352,14 @@ $ nativefier http://google.com --crash-reporter https://electron-crash-reporter.
 
 Sets a default zoom factor to be used when the app is opened, defaults to `1.0`.
 
+#### [single-instance]
+
+```
+--single-instance
+```
+
+Prevents application from being run multiple times. If such an attempt occurs the already running instance is brought to front.
+
 ## Programmatic API
 
 You can use the Nativefier programmatic API as well.
@@ -385,7 +394,8 @@ var options = {
     ignoreCertificate: false,
     insecure: false,
     honest: false,
-    zoom: 1.0
+    zoom: 1.0,
+    singleInstance: false
 };
 
 nativefier(options, function(error, appPath) {

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -117,7 +117,8 @@ function selectAppArgs(options) {
         disableDevTools: options.disableDevTools,
         zoom: options.zoom,
         internalUrls: options.internalUrls,
-        crashReporter: options.crashReporter
+        crashReporter: options.crashReporter,
+        singleInstance: options.singleInstance
     };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,6 +53,7 @@ if (require.main === module) {
         .option('--zoom <value>', 'default zoom factor to use when the app is opened, defaults to 1.0', parseFloat)
         .option('--internal-urls <value>', 'regular expression of URLs to consider "internal"; all other URLs will be opened in an external browser.  (default: URLs on same second-level domain as app)')
         .option('--crash-reporter <value>', 'remote server URL to send crash reports')
+        .option('--single-instance', 'allow only a single instance of the application')
         .parse(process.argv);
 
     if (!process.argv.slice(2).length) {

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -68,7 +68,8 @@ function optionsFactory(inpOptions, callback) {
         // workaround for electron-packager#375
         tmpdir: false,
         zoom: inpOptions.zoom || 1.0,
-        internalUrls: inpOptions.internalUrls || null
+        internalUrls: inpOptions.internalUrls || null,
+        singleInstance: inpOptions.singleInstance || false
     };
 
     if (options.verbose) {


### PR DESCRIPTION
This PR adds a `--single-instance` option that prevents application from being run multiple times. If such a situation occurs, the already running instance is brought to front.

Fixes #322.