### PR TITLE
Fix #327 - Update dependencies, enforce Node>=4.0, and default to Electron 1.6.6

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,7 @@
   "main": "lib/main.js",
   "dependencies": {
     "electron-dl": "^1.1.0",
-    "electron-window-state": "^3.0.3",
+    "electron-window-state": "^4.1.0",
     "source-map-support": "^0.4.0",
     "wurl": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -36,25 +36,25 @@
   },
   "homepage": "https://github.com/jiahaog/nativefier#readme",
   "dependencies": {
-    "async": "^1.5.2",
-    "axios": "^0.11.1",
+    "async": "^2.3.0",
+    "axios": "^0.16.1",
     "babel-polyfill": "^6.7.2",
-    "cheerio": "^0.20.0",
+    "cheerio": "^0.22.0",
     "commander": "^2.9.0",
-    "electron-packager": "^7.0.1",
+    "electron-packager": "^8.6.0",
     "gitcloud": "^0.1.0",
     "hasbin": "^1.2.0",
     "lodash": "^4.0.0",
     "loglevel": "^1.4.0",
     "ncp": "^2.0.0",
     "page-icon": "^0.3.0",
-    "progress": "^1.1.8",
+    "progress": "^2.0.0",
     "request": "^2.67.0",
     "sanitize-filename": "^1.5.3",
     "shelljs": "^0.7.0",
     "source-map-support": "^0.4.0",
-    "tmp": "0.0.28",
-    "validator": "^5.2.0"
+    "tmp": "0.0.31",
+    "validator": "^7.0.0"
   },
   "babel": {
     "presets": [
@@ -72,11 +72,14 @@
     "eslint-config-google": "^0.5.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",
-    "gulp-istanbul": "^0.10.3",
-    "gulp-mocha": "^2.2.0",
-    "gulp-sourcemaps": "^1.6.0",
+    "gulp-istanbul": "^1.1.1",
+    "gulp-mocha": "^4.3.0",
+    "gulp-sourcemaps": "^2.6.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.5",
     "webpack-stream": "^3.1.0"
+  },
+  "engines": {
+    "node": ">= 4.0"
   }
 }

--- a/src/infer/inferUserAgent.js
+++ b/src/infer/inferUserAgent.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import log from 'loglevel';
 
 const ELECTRON_VERSIONS_URL = 'https://atom.io/download/atom-shell/index.json';
-const DEFAULT_CHROME_VERSION = '47.0.2526.73';
+const DEFAULT_CHROME_VERSION = '56.0.2924.87';
 
 function getChromeVersionForElectronVersion(electronVersion, url = ELECTRON_VERSIONS_URL) {
     return axios.get(url, {timeout: 5000})
@@ -27,10 +27,10 @@ export function getUserAgentString(chromeVersion, platform) {
     let userAgent;
     switch (platform) {
         case 'darwin':
-            userAgent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
+            userAgent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
             break;
         case 'win32':
-            userAgent = `Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
+            userAgent = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
             break;
         case 'linux':
             userAgent = `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -14,7 +14,7 @@ import packageJson from './../../package.json';
 const {inferPlatform, inferArch} = inferOs;
 
 const PLACEHOLDER_APP_DIR = path.join(__dirname, '../../', 'app');
-const ELECTRON_VERSION = '1.1.3';
+const ELECTRON_VERSION = '1.6.6';
 
 const DEFAULT_APP_NAME = 'APP';
 
@@ -37,7 +37,7 @@ function optionsFactory(inpOptions, callback) {
         targetUrl: normalizeUrl(inpOptions.targetUrl),
         platform: inpOptions.platform || inferPlatform(),
         arch: inpOptions.arch || inferArch(),
-        version: inpOptions.electronVersion || ELECTRON_VERSION,
+        electronVersion: inpOptions.electronVersion || ELECTRON_VERSION,
         nativefierVersion: packageJson.version,
         out: inpOptions.out || process.cwd(),
         overwrite: inpOptions.overwrite,
@@ -108,7 +108,7 @@ function optionsFactory(inpOptions, callback) {
                 callback();
                 return;
             }
-            inferUserAgent(options.version, options.platform)
+            inferUserAgent(options.electronVersion, options.platform)
                 .then(userAgent => {
                     options.userAgent = userAgent;
                     callback();

--- a/test/module/inferUserAgent-spec.js
+++ b/test/module/inferUserAgent-spec.js
@@ -5,8 +5,8 @@ import _ from 'lodash';
 const assert = chai.assert;
 
 const TEST_RESULT = {
-    darwin: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
-    win32: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
+    darwin: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
+    win32: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
     linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36'
 };
 
@@ -35,11 +35,11 @@ describe('Infer User Agent', function() {
 
     it('Connection error will still get a user agent', function(done) {
         const TIMEOUT_URL = 'http://www.google.com:81/';
-        inferUserAgent('0.37.1', 'darwin', TIMEOUT_URL)
+        inferUserAgent('1.6.7', 'darwin', TIMEOUT_URL)
             .then(userAgent => {
                 assert.equal(
                     userAgent,
-                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36',
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36',
                     'Expect default user agent on connection error'
                 );
                 done();
@@ -47,4 +47,3 @@ describe('Infer User Agent', function() {
             .catch(done);
     });
 });
-


### PR DESCRIPTION
Do ***NOT*** merge this PR right now, it deserves some time of cross-OS testing.