### PR TITLE
Fix for executable name being 'Electron' always under Windows, Issue #28

### DIFF
--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -18,7 +18,9 @@ export default function (inpOptions) {
     dir: PLACEHOLDER_APP_DIR,
     name: inpOptions.name,
     win32metadata: {
-      ProductName: inpOptions.name
+      ProductName: inpOptions.name,
+      InternalName: inpOptions.name,
+      FileDescription: inpOptions.name,
     },
     targetUrl: normalizeUrl(inpOptions.targetUrl),
     platform: inpOptions.platform || inferPlatform(),

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -17,6 +17,9 @@ export default function (inpOptions) {
   const options = {
     dir: PLACEHOLDER_APP_DIR,
     name: inpOptions.name,
+    win32metadata: {
+      ProductName: inpOptions.name
+    },
     targetUrl: normalizeUrl(inpOptions.targetUrl),
     platform: inpOptions.platform || inferPlatform(),
     arch: inpOptions.arch || inferArch(),


### PR DESCRIPTION
This fixes issue #28 