### PR TITLE
Added support for --disk-cache-size

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -29,6 +29,10 @@ if (appArgs.ignoreCertificate) {
   app.commandLine.appendSwitch('ignore-certificate-errors');
 }
 
+if (appArgs.diskCacheSize) {
+  app.commandLine.appendSwitch('disk-cache-size', appArgs.diskCacheSize);
+}
+
 // do nothing for setDockBadge if not OSX
 let setDockBadge = () => {};
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,7 @@
     - [[insecure]](#insecure)
     - [[flash]](#flash)
     - [[flash-path]](#flash-path)
+    - [[disk-cache-size]](#disk-cache-size)
     - [[inject]](#inject)
     - [[full-screen]](#full-screen)
     - [[maximize]](#maximize)
@@ -265,6 +266,13 @@ Take note that if this flag is specified, the `--insecure` flag will be added au
 ```
 
 You can also specify the path to the Chrome flash plugin directly with this flag. The path can be found at [chrome://plugins](chrome://plugins), under `Adobe Flash Player` > `Location`. This flag automatically enables the `--flash` flag as well.
+
+#### [disk-cache-size]
+
+```
+--disk-cache-size <value>
+```
+Forces the maximum disk space to be used by the disk cache. Value is given in bytes.
 
 #### [inject]
 

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -28,6 +28,7 @@ function selectAppArgs(options) {
     ignoreCertificate: options.ignoreCertificate,
     insecure: options.insecure,
     flashPluginDir: options.flashPluginDir,
+    diskCacheSize: options.diskCacheSize,
     fullScreen: options.fullScreen,
     hideWindowFrame: options.hideWindowFrame,
     maximize: options.maximize,

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,6 +41,7 @@ if (require.main === module) {
     .option('--insecure', 'enable loading of insecure content, defaults to false')
     .option('--flash', 'if flash should be enabled')
     .option('--flash-path <value>', 'path to Chrome flash plugin, find it in `Chrome://plugins`')
+    .option('--disk-cache-size <value>', 'forces the maximum disk space (in bytes) to be used by the disk cache')
     .option('--inject <value>', 'path to a CSS/JS file to be injected', collect, [])
     .option('--full-screen', 'if the app should always be started in full screen')
     .option('--maximize', 'if the app should always be started maximized')

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -44,6 +44,7 @@ export default function (inpOptions) {
     ignoreCertificate: inpOptions.ignoreCertificate || false,
     insecure: inpOptions.insecure || false,
     flashPluginDir: inpOptions.flashPath || inpOptions.flash || null,
+    diskCacheSize: inpOptions.diskCacheSize || null,
     inject: inpOptions.inject || null,
     ignore: 'src',
     fullScreen: inpOptions.fullScreen || false,


### PR DESCRIPTION
Electron [now has support](https://github.com/electron/electron/pull/9435) for this flag, and I found it useful to expose it in Nativefier. I have an app that needs to cache som larger files, and it was unable to do so without increasing the cache size. This PR solved the issue for me—and maybe the flag will be useful to someone else too.