### PR TITLE
Force fullscreen when options.fullScreen is true

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -88,12 +88,6 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
 
   mainWindowState.manage(mainWindow);
 
-  // after first run, no longer force full screen to be true
-  if (options.fullScreen) {
-    options.fullScreen = undefined;
-    fs.writeFileSync(path.join(__dirname, '..', 'nativefier.json'), JSON.stringify(options));
-  }
-
   // after first run, no longer force maximize to be true
   if (options.maximize) {
     mainWindow.maximize();


### PR DESCRIPTION
Fixes #402, as electron-window-state does not appear to remember fullscreen in all cases.