### PR TITLE
New feature: options for --ignore-gpu-blacklist and --enable-es3-apis Chrome flags

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -29,6 +29,14 @@ if (appArgs.ignoreCertificate) {
   app.commandLine.appendSwitch('ignore-certificate-errors');
 }
 
+if (appArgs.ignoreGpuBlacklist) {
+  app.commandLine.appendSwitch('ignore-gpu-blacklist');
+}
+
+if (appArgs.enableEs3Apis) {
+  app.commandLine.appendSwitch('enable-es3-apis');
+}
+
 if (appArgs.diskCacheSize) {
   app.commandLine.appendSwitch('disk-cache-size', appArgs.diskCacheSize);
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,6 +242,21 @@ If this flag is passed, it will not override the user agent.
 ```
 Forces the packaged app to ignore certificate errors.
 
+#### [ignore-gpu-blacklist]
+
+```
+--ignore-gpu-blacklist
+```
+Passes the ignore-gpu-blacklist flag to the Chrome engine, to allow for WebGl apps to work on non supported graphics cards.
+
+#### [enable-es3-apis]
+
+```
+--enable-es3-apis
+```
+Passes the enable-es3-apis flag to the Chrome engine, to force the activation of WebGl 2.0.
+
+
 #### [insecure]
 
 ```
@@ -401,6 +416,8 @@ var options = {
     fastQuit: false,
     userAgent: 'Mozilla ...', // will infer a default for your current system
     ignoreCertificate: false,
+    ignoreGpuBlacklist: false,
+    enableEs3Apis: false,
     insecure: false,
     honest: false,
     zoom: 1.0,

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -26,6 +26,8 @@ function selectAppArgs(options) {
     userAgent: options.userAgent,
     nativefierVersion: options.nativefierVersion,
     ignoreCertificate: options.ignoreCertificate,
+    ignoreGpuBlacklist: options.ignoreGpuBlacklist,
+    enableEs3Apis: options.enableEs3Apis,
     insecure: options.insecure,
     flashPluginDir: options.flashPluginDir,
     diskCacheSize: options.diskCacheSize,

--- a/src/cli.js
+++ b/src/cli.js
@@ -38,6 +38,8 @@ if (require.main === module) {
     .option('-u, --user-agent <value>', 'set the user agent string for the app')
     .option('--honest', 'prevent the nativefied app from changing the user agent string to masquerade as a regular chrome browser')
     .option('--ignore-certificate', 'ignore certificate related errors')
+    .option('--ignore-gpu-blacklist', 'allow WebGl apps to work on non supported graphics cards')
+    .option('--enable-es3-apis', 'force activation of WebGl 2.0')
     .option('--insecure', 'enable loading of insecure content, defaults to false')
     .option('--flash', 'if flash should be enabled')
     .option('--flash-path <value>', 'path to Chrome flash plugin, find it in `Chrome://plugins`')

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -42,6 +42,8 @@ export default function (inpOptions) {
     fastQuit: inpOptions.fastQuit || false,
     userAgent: inpOptions.userAgent,
     ignoreCertificate: inpOptions.ignoreCertificate || false,
+    ignoreGpuBlacklist: inpOptions.ignoreGpuBlacklist || false,
+    enableEs3Apis: inpOptions.enableEs3Apis || false,
     insecure: inpOptions.insecure || false,
     flashPluginDir: inpOptions.flashPath || inpOptions.flash || null,
     diskCacheSize: inpOptions.diskCacheSize || null,


### PR DESCRIPTION
Add options (--ignore-gpu-blacklist and --enable-es3-apis) to allow for WebGl apps to work on legacy or unsupported graphics cards by Chrome