### PR TITLE
Update title counter regex

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -177,7 +177,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
 
   if (options.counter) {
     mainWindow.on('page-title-updated', (e, title) => {
-      const itemCountRegex = /[([{](\d*?)[}\])]/;
+      const itemCountRegex = /[([{](\d*?)\+?[}\])]/;
       const match = itemCountRegex.exec(title);
       if (match) {
         setDockBadge(match[1]);


### PR DESCRIPTION
Some websites use this format in their title count: `(9+)`.
This commit adds support for those and it will not affect the previous behavior.