### PR TITLE
fix: add new params to buildApp (issue #438)

### DIFF
--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -40,6 +40,11 @@ function selectAppArgs(options) {
     internalUrls: options.internalUrls,
     crashReporter: options.crashReporter,
     singleInstance: options.singleInstance,
+    appCopyright: options.appCopyright,
+    appVersion: options.appVersion,
+    buildVersion: options.buildVersion,
+    win32metadata: options.win32metadata,
+    versionString: options.versionString,
     processEnvs: options.processEnvs,
   };
 }


### PR DESCRIPTION
Ok, I think that these params were left out of one of the PR's that I made.  Fixes issue #438.