### PR TITLE
Document internal-urls option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -298,7 +298,13 @@ Forces the packaged app to ignore web security errors, such as [Mixed Content](h
 ```
 --internal-urls <regex>
 ```
-Customize what should open in an external browser. If the URL does not match the regex, it will open in an external browser.
+Regular expression of URLs to consider "internal"; all other URLs will be opened in an external browser. Defaults to URLs on same second-level domain as app.
+
+Example:
+
+```bash
+nativefier https://google.com --internal-urls ".*?\.google\.*?"
+```
 
 #### [flash]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,7 @@
     - [[honest]](#honest)
     - [[ignore-certificate]](#ignore-certificate)
     - [[insecure]](#insecure)
+    - [[internal-urls]](#internal-urls)
     - [[flash]](#flash)
     - [[flash-path]](#flash-path)
     - [[disk-cache-size]](#disk-cache-size)
@@ -290,6 +291,14 @@ Passes the enable-es3-apis flag to the Chrome engine, to force the activation of
 --insecure
 ```
 Forces the packaged app to ignore web security errors, such as [Mixed Content](https://developer.mozilla.org/en-US/docs/Security/Mixed_content) errors when receiving HTTP content on a HTTPS site.
+
+
+#### [internal-urls]
+
+```
+--internal-urls <regex>
+```
+Customize what should open in an external browser.
 
 #### [flash]
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -298,7 +298,7 @@ Forces the packaged app to ignore web security errors, such as [Mixed Content](h
 ```
 --internal-urls <regex>
 ```
-Customize what should open in an external browser.
+Customize what should open in an external browser. If the URL does not match the regex, it will open in an external browser.
 
 #### [flash]
 


### PR DESCRIPTION
Update readme to include documentation on `internal-urls` option