### PR TITLE
Fix #486 for windows : missing icon.ico

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -7,7 +7,7 @@ import createMenu from './../menu/menu';
 import initContextMenu from './../contextMenu/contextMenu';
 
 const {
-  isOSX, linkIsInternal, getCssToInject, shouldInjectCss, getAppIcon
+  isOSX, linkIsInternal, getCssToInject, shouldInjectCss, getAppIcon,
 } = helpers;
 
 const ZOOM_INTERVAL = 0.1;

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -7,7 +7,7 @@ import createMenu from './../menu/menu';
 import initContextMenu from './../contextMenu/contextMenu';
 
 const {
-  isOSX, linkIsInternal, getCssToInject, shouldInjectCss,
+  isOSX, linkIsInternal, getCssToInject, shouldInjectCss, getAppIcon
 } = helpers;
 
 const ZOOM_INTERVAL = 0.1;
@@ -86,7 +86,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
       zoomFactor: options.zoom,
     },
     // after webpack path here should reference `resources/app/`
-    icon: path.join(__dirname, '../', '/icon.png'),
+    icon: getAppIcon(),
     // set to undefined and not false because explicitly setting to false will disable full screen
     fullscreen: options.fullScreen || undefined,
   });

--- a/app/src/components/trayIcon/trayIcon.js
+++ b/app/src/components/trayIcon/trayIcon.js
@@ -1,8 +1,11 @@
 import path from 'path';
+import helpers from './../../helpers/helpers';
 
 const {
-  app, Tray, Menu, ipcMain,
+  app, Tray, Menu, ipcMain, nativeImage
 } = require('electron');
+
+const { getAppIcon } = helpers;
 
 /**
  *
@@ -14,8 +17,9 @@ function createTrayIcon(inpOptions, mainWindow) {
   const options = Object.assign({}, inpOptions);
 
   if (options.tray) {
-    const iconPath = path.join(__dirname, '../', '/icon.png');
-    const appIcon = new Tray(iconPath);
+    const iconPath = getAppIcon();
+    const nimage = nativeImage.createFromPath(iconPath);
+    const appIcon = new Tray(nimage);
 
     const onClick = () => {
       if (mainWindow.isVisible()) {

--- a/app/src/components/trayIcon/trayIcon.js
+++ b/app/src/components/trayIcon/trayIcon.js
@@ -1,8 +1,7 @@
-import path from 'path';
 import helpers from './../../helpers/helpers';
 
 const {
-  app, Tray, Menu, ipcMain, nativeImage
+  app, Tray, Menu, ipcMain, nativeImage,
 } = require('electron');
 
 const { getAppIcon } = helpers;

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -55,6 +55,10 @@ function debugLog(browserWindow, message) {
   console.log(message);
 }
 
+function getAppIcon() {
+  return path.join(__dirname, '../', `/icon.${isWindows() ? 'ico' : 'png'}`);
+}
+
 export default {
   isOSX,
   isLinux,
@@ -63,4 +67,5 @@ export default {
   getCssToInject,
   debugLog,
   shouldInjectCss,
+  getAppIcon,
 };


### PR DESCRIPTION
#486
When building Windows app, "icon.png" doesn't exists but it generates an "icon.ico", so I created a function in helpers.js that returns the correct icon file. I don't know what can happen on OSX (I can't test it), I saw that there is a conversion to an ".icns" file, maybe we must also handle OSX icon file in this helper function.

Also fix Windows specific error on tray icon load (like on this comment : https://github.com/electron/electron/issues/7657#issuecomment-317073318)
