### PR TITLE
Add support for MAS builds

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -93,7 +93,7 @@ The name of the application, which will affect strings in titles and the icon.
 ```
 -p, --platform <value>
 ```
-Automatically determined based on the current OS. Can be overwritten by specifying either `linux`, `windows`, or `osx`.
+Automatically determined based on the current OS. Can be overwritten by specifying either `linux`, `windows`, `osx` or `mas` for a Mac App Store specific build.
 
 The alternative values `win32` (for Windows) or `darwin`, `mac` (for OSX) can also be used.
 

--- a/src/build/buildMain.js
+++ b/src/build/buildMain.js
@@ -63,7 +63,7 @@ function maybeCopyIcons(options, appPath, callback) {
     return;
   }
 
-  if (options.platform === 'darwin') {
+  if (options.platform === 'darwin' || options.platform === 'mas') {
     callback();
     return;
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -43,7 +43,7 @@ if (require.main === module) {
       program.out = appDir;
     })
     .option('-n, --name <value>', 'app name')
-    .option('-p, --platform <value>', '\'osx\', \'linux\' or \'windows\'')
+    .option('-p, --platform <value>', '\'osx\', \'mas\', \'linux\' or \'windows\'')
     .option('-a, --arch <value>', '\'ia32\' or \'x64\' or \'armv7l\'')
     .option('--app-version <value>', 'The release version of the application.  Maps to the `ProductVersion` metadata property on Windows, and `CFBundleShortVersionString` on OS X.')
     .option('--build-version <value>', 'The build version of the application. Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on OS X.')

--- a/src/infer/inferOs.js
+++ b/src/infer/inferOs.js
@@ -2,7 +2,7 @@ import os from 'os';
 
 function inferPlatform() {
   const platform = os.platform();
-  if (platform === 'darwin' || platform === 'win32' || platform === 'linux') {
+  if ((platform === 'darwin' || platform === 'mas') || platform === 'win32' || platform === 'linux') {
     return platform;
   }
 

--- a/src/infer/inferUserAgent.js
+++ b/src/infer/inferUserAgent.js
@@ -30,6 +30,7 @@ export function getUserAgentString(chromeVersion, platform) {
   let userAgent;
   switch (platform) {
     case 'darwin':
+    case 'mas':
       userAgent = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
       break;
     case 'win32':

--- a/test/module/inferUserAgentSpec.js
+++ b/test/module/inferUserAgentSpec.js
@@ -6,6 +6,7 @@ const { assert } = chai;
 
 const TEST_RESULT = {
   darwin: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
+  mas: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
   win32: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
   linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
 };


### PR DESCRIPTION
I needed to roll a nativefied app that would pass the Mac Application Store's checks, which rejects some of the now deprecated QuickTime API's included in the `osx` or `darwin` builds.

This extends nativefier to support `--platform=mas`, which is already supported by the underlying `electron-packager` dependency.