### PR TITLE
Fix #522 - Add --start-in-tray CLI flag to let app start in background

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -113,6 +113,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         // Whether the window should always stay on top of other windows. Default is false.
         alwaysOnTop: options.alwaysOnTop,
         titleBarStyle: options.titleBarStyle,
+        show: options.tray !== 'start-in-tray',
       },
       DEFAULT_WINDOW_OPTIONS,
     ),

--- a/docs/api.md
+++ b/docs/api.md
@@ -519,10 +519,12 @@ Prevents application from being run multiple times. If such an attempt occurs th
 #### [tray]
 
 ```
---tray
+--tray [start-in-tray]
 ```
 
 Application will stay as an icon in the system tray. Prevents application from being closed from clicking the window close button.
+
+When the optional argument `start-in-tray` is provided, i.e. the application is started using `--tray start-in-tray`, the main window will not be shown on first start.
 
 #### [basic-auth-username]
 


### PR DESCRIPTION
This fixes #522 by introducing `--start-in-tray` as new CLI flag.