### PR TITLE
FIX #575: Create tmp dir with mode 0755

### DIFF
--- a/src/build/buildMain.js
+++ b/src/build/buildMain.js
@@ -153,7 +153,7 @@ function buildMain(inpOptions, callback) {
   const options = Object.assign({}, inpOptions);
 
   // pre process app
-  const tmpObj = tmp.dirSync({ unsafeCleanup: true });
+  const tmpObj = tmp.dirSync({ mode: '0755', unsafeCleanup: true });
   const tmpPath = tmpObj.name;
 
   // todo check if this is still needed on later version of packager


### PR DESCRIPTION
By default, the tmp module creates directories with permissions `0700`.  It appears that the `app` folder created by `buildApp` has its permissions set to those of the enclosing folder, so this results in the behavior reported in #575. By setting the tmp dir permissions explicitly to `0755`, as this change does, the `app` folder also gets those permissions, thereby resolving the issue.