### PR TITLE
FIX #474: Use setZoomFactor instead of sending change-zoom event

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -106,16 +106,16 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
 
   const onZoomIn = () => {
     currentZoom += ZOOM_INTERVAL;
-    mainWindow.webContents.send('change-zoom', currentZoom);
+    mainWindow.webContents.setZoomFactor(currentZoom);
   };
 
   const onZoomOut = () => {
     currentZoom -= ZOOM_INTERVAL;
-    mainWindow.webContents.send('change-zoom', currentZoom);
+    mainWindow.webContents.setZoomFactor(currentZoom);
   };
 
   const onZoomReset = () => {
-    mainWindow.webContents.send('change-zoom', options.zoom);
+    mainWindow.webContents.setZoomFactor(options.zoom);
   };
 
   const clearAppData = () => {

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -102,16 +102,16 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     fs.writeFileSync(path.join(__dirname, '..', 'nativefier.json'), JSON.stringify(options));
   }
 
-  let currentZoom = options.zoom;
-
   const onZoomIn = () => {
-    currentZoom += ZOOM_INTERVAL;
-    mainWindow.webContents.setZoomFactor(currentZoom);
+    mainWindow.webContents.getZoomFactor((zoomFactor) => {
+      mainWindow.webContents.setZoomFactor(zoomFactor + ZOOM_INTERVAL);
+    });
   };
 
   const onZoomOut = () => {
-    currentZoom -= ZOOM_INTERVAL;
-    mainWindow.webContents.setZoomFactor(currentZoom);
+    mainWindow.webContents.getZoomFactor((zoomFactor) => {
+      mainWindow.webContents.setZoomFactor(zoomFactor - ZOOM_INTERVAL);
+    });
   };
 
   const onZoomReset = () => {

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -102,17 +102,15 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     fs.writeFileSync(path.join(__dirname, '..', 'nativefier.json'), JSON.stringify(options));
   }
 
-  const onZoomIn = () => {
-    mainWindow.webContents.getZoomFactor((zoomFactor) => {
-      mainWindow.webContents.setZoomFactor(zoomFactor + ZOOM_INTERVAL);
+  const adjustWindowZoom = (window, adjustment) => {
+    window.webContents.getZoomFactor((zoomFactor) => {
+      window.webContents.setZoomFactor(zoomFactor + adjustment);
     });
   };
 
-  const onZoomOut = () => {
-    mainWindow.webContents.getZoomFactor((zoomFactor) => {
-      mainWindow.webContents.setZoomFactor(zoomFactor - ZOOM_INTERVAL);
-    });
-  };
+  const onZoomIn = () => adjustWindowZoom(mainWindow, ZOOM_INTERVAL);
+
+  const onZoomOut = () => adjustWindowZoom(mainWindow, -ZOOM_INTERVAL);
 
   const onZoomReset = () => {
     mainWindow.webContents.setZoomFactor(options.zoom);

--- a/app/src/static/preload.js
+++ b/app/src/static/preload.js
@@ -1,7 +1,7 @@
 /**
  Preload file that will be executed in the renderer process
  */
-import { ipcRenderer, webFrame } from 'electron';
+import { ipcRenderer } from 'electron';
 import path from 'path';
 import fs from 'fs';
 
@@ -77,8 +77,4 @@ ipcRenderer.on('params', (event, message) => {
 ipcRenderer.on('debug', (event, message) => {
   // eslint-disable-next-line no-console
   log.info('debug:', message);
-});
-
-ipcRenderer.on('change-zoom', (event, message) => {
-  webFrame.setZoomFactor(message);
 });


### PR DESCRIPTION
The method of setting the zoom factor on the web frame inside of the renderer doesn't persist across navigation, as reported in #474. This change replaces instances of sending the 'change-zoom' event with calls to the setZoomFactor webContents API.