### PR TITLE
FIX #199: Add support for using sips when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You need [Xcode](https://developer.apple.com/xcode/) installed.
 
 #### [imagemagick](http://www.imagemagick.org/script/index.php)
 
-Make sure `convert` and `identify` are in your `$PATH`.
+Make sure `convert` and `identify` are in your `$PATH`. If the tools are not found then nativefier will fallback on using the built-in macOS tool `sips` to perform the conversion.
 
 ### Flash
 

--- a/bin/convertToIcns
+++ b/bin/convertToIcns
@@ -9,16 +9,21 @@
 # exit the shell script on error immediately
 set -e
 
-# import script as variable
-CONVERT_TO_PNG="${BASH_SOURCE%/*}/convertToPng"
-
 # Exec Paths
-type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Convert executable"; exit 1; }
-type iconutil >/dev/null 2>&1 || { echo >&2 "Cannot find required iconutil executable"; exit 1; }
+HAVE_IMAGEMAGICK=
+HAVE_ICONUTIL=
+HAVE_SIPS=
+
+type convert &>/dev/null && HAVE_IMAGEMAGICK=true
+type iconutil &>/dev/null && HAVE_ICONUTIL=true
+type sips &>/dev/null && HAVE_SIPS=true
+
+[[ -z "$HAVE_ICONUTIL" ]] && { echo >&2 "Cannot find required iconutil executable"; exit 1; }
+[[ -z "$HAVE_IMAGEMAGICK" && -z "$HAVE_SIPS" ]] && { echo >&2 "Cannot find required image converter, please install sips or imagemagick"; exit 1; }
 
 # Parameters
-SOURCE=$1
-DEST=$2
+SOURCE="$1"
+DEST="$2"
 
 # Check source and destination arguments
 if [ -z "${SOURCE}" ]; then
@@ -31,37 +36,16 @@ if [ -z "${DEST}" ]; then
 	exit 1
 fi
 
-# File Infrastructure
-NAME=$(basename "${SOURCE}")
-EXT="${NAME##*.}"
-BASE="${NAME%.*}"
-TEMP_DIR="temp_icon"
-ICONSET="${BASE}.iconset"
+TEMP_DIR="$(mktemp -d)"
+ICONSET="${TEMP_DIR}/converted.iconset"
 
 function cleanUp() {
     rm -rf "${TEMP_DIR}"
-    rm -rf "${ICONSET}"
 }
 
 trap cleanUp EXIT
 
-mkdir -p "${TEMP_DIR}"
-mkdir -p "${ICONSET}"
-
-PNG_PATH="${TEMP_DIR}/icon.png"
-${CONVERT_TO_PNG} "${SOURCE}" "${PNG_PATH}"
-
-# Resample image into iconset
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 16x16 "${ICONSET}/icon_16x16.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_16x16@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 32x32 "${ICONSET}/icon_32x32.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 64x64 "${ICONSET}/icon_32x32@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 128x128 "${ICONSET}/icon_128x128.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_128x128@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 256x256 "${ICONSET}/icon_256x256.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_256x256@2x.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 512x512 "${ICONSET}/icon_512x512.png"
-convert "${PNG_PATH}" -define png:big-depth=16 -define png:color-type=6 -sample 1024x1024 "${ICONSET}/icon_512x512@2x.png"
+"${BASH_SOURCE%/*}/convertToIconset" "${SOURCE}" "${ICONSET}"
 
 # Create an icns file lefrom the iconset
 iconutil -c icns "${ICONSET}" -o "${DEST}"

--- a/bin/convertToIcns
+++ b/bin/convertToIcns
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ### USAGE
 

--- a/bin/convertToIconset
+++ b/bin/convertToIconset
@@ -48,14 +48,18 @@ if [ -z "${DEST}" ]; then
 	echo >&2 "No destination specified"; exit 1
 fi
 
-if [[ -e "$(which convert)" ]]; then
+HAVE_IMAGEMAGICK=
+HAVE_SIPS=
+
+type convert &>/dev/null && HAVE_IMAGEMAGICK=true
+type sips &>/dev/null && HAVE_SIPS=true
+
+if [[ ! -z "$HAVE_IMAGEMAGICK" ]]; then
   PNG_PATH="$(mktemp -d)/icon.png"
   "${BASH_SOURCE%/*}/convertToPng" "${SOURCE}" "${PNG_PATH}"
   make_iconset_imagemagick "${PNG_PATH}" "${DEST}"
-elif [[ -e "$(which sips)" ]]; then
+elif [[ ! -z "$HAVE_SIPS" ]]; then
   make_iconset_sips "${SOURCE}" "${DEST}"
 else
   echo >&2 "Cannot find convert or sips executables"; exit 1;
 fi
-
-true

--- a/bin/convertToIconset
+++ b/bin/convertToIconset
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ### USAGE
 

--- a/bin/convertToIconset
+++ b/bin/convertToIconset
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+### USAGE
+
+# ./convertToIconset <input png> <outp iconset>
+# Example
+# ./convertToIconset ~/sample.png ~/Desktop/converted.iconset
+
+# exit the shell script on error immediately
+set -e
+
+make_iconset_imagemagick() {
+  local file iconset
+  file="${1}"
+  iconset="${2}"
+
+  mkdir "$iconset"
+
+  for size in {16,32,64,128,256,512}; do
+    convert "${file}" -define png:big-depth=16 -define png:color-type=6 -sample "${size}x${size}" "${iconset}/icon_${size}x${size}.png"
+    convert "${file}" -define png:big-depth=16 -define png:color-type=6 -sample "$((size * 2))x$((size * 2))" "${iconset}/icon_${size}x${size}@2x.png"
+  done
+}
+
+make_iconset_sips() {
+  local file iconset
+  file="${1}"
+  iconset="${2}"
+
+  mkdir "$iconset"
+
+  for size in {16,32,64,128,256,512}; do
+    sips --setProperty format png --resampleHeightWidth "${size}" "${size}" "${file}" --out "${iconset}/icon_${size}x${size}.png" &> /dev/null
+    sips --setProperty format png --resampleHeightWidth "$((size * 2))" "$((size * 2))" "${file}" --out "${iconset}/icon_${size}x${size}@2x.png" &> /dev/null
+  done
+}
+
+# Parameters
+SOURCE="$1"
+DEST="$2"
+
+# Check source and destination arguments
+if [ -z "${SOURCE}" ]; then
+	echo >&2 "No source image specified"; exit 1
+fi
+
+if [ -z "${DEST}" ]; then
+	echo >&2 "No destination specified"; exit 1
+fi
+
+if [[ -e "$(which convert)" ]]; then
+  PNG_PATH="$(mktemp -d)/icon.png"
+  "${BASH_SOURCE%/*}/convertToPng" "${SOURCE}" "${PNG_PATH}"
+  make_iconset_imagemagick "${PNG_PATH}" "${DEST}"
+elif [[ -e "$(which sips)" ]]; then
+  make_iconset_sips "${SOURCE}" "${DEST}"
+else
+  echo >&2 "Cannot find convert or sips executables"; exit 1;
+fi
+
+true

--- a/bin/convertToPng
+++ b/bin/convertToPng
@@ -12,8 +12,8 @@ type convert >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Con
 type identify >/dev/null 2>&1 || { echo >&2 "Cannot find required ImageMagick Identify executable"; exit 1; }
 
 # Parameters
-SOURCE=$1
-DEST=$2
+SOURCE="$1"
+DEST="$2"
 
 # Check source and destination arguments
 if [ -z "${SOURCE}" ]; then
@@ -42,7 +42,7 @@ mkdir -p "${TEMP_DIR}"
 
 # check if .ico is a sequence
 # pipe into cat so no exit code is given for grep if no matches are found
-IS_ICO_SET="$(identify ${SOURCE} | grep -e "\w\.ico\[0" | cat )"
+IS_ICO_SET="$(identify "${SOURCE}" | grep -e "\w\.ico\[0" | cat )"
 
 convert "${SOURCE}" "${TEMP_DIR}/${BASE}.png"
 if [ "${IS_ICO_SET}" ]; then


### PR DESCRIPTION
This change eliminates the requirement for imagemagick to be present on macOS for icon conversion.

This PR is based off of the code from #279 and fixes #199.

