### PR TITLE
FIX #364: Add --disable-gpu flag to disable hardware acceleration

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -38,6 +38,10 @@ if (appArgs.ignoreCertificate) {
   app.commandLine.appendSwitch('ignore-certificate-errors');
 }
 
+if (appArgs.disableGpu) {
+  app.disableHardwareAcceleration();
+}
+
 if (appArgs.ignoreGpuBlacklist) {
   app.commandLine.appendSwitch('ignore-gpu-blacklist');
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,7 @@
     - [[basic-auth-username]](#basic-auth-username)
     - [[basic-auth-password]](#basic-auth-username)
     - [[always-on-top]](#always-on-top)
+    - [[disable-gpu]](#disable-gpu)
 - [Programmatic API](#programmatic-api)
 
 ## Command Line
@@ -297,6 +298,13 @@ If this flag is passed, it will not override the user agent.
 --ignore-certificate
 ```
 Forces the packaged app to ignore certificate errors.
+
+#### [disable-gpu]
+
+```
+--disable-gpu
+```
+Disable hardware acceleration for the packaged application.
 
 #### [ignore-gpu-blacklist]
 

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -29,6 +29,7 @@ function selectAppArgs(options) {
     userAgent: options.userAgent,
     nativefierVersion: options.nativefierVersion,
     ignoreCertificate: options.ignoreCertificate,
+    disableGpu: options.disableGpu,
     ignoreGpuBlacklist: options.ignoreGpuBlacklist,
     enableEs3Apis: options.enableEs3Apis,
     insecure: options.insecure,

--- a/src/cli.js
+++ b/src/cli.js
@@ -68,6 +68,7 @@ if (require.main === module) {
     .option('-u, --user-agent <value>', 'set the user agent string for the app')
     .option('--honest', 'prevent the nativefied app from changing the user agent string to masquerade as a regular chrome browser')
     .option('--ignore-certificate', 'ignore certificate related errors')
+    .option('--disable-gpu', 'disable hardware acceleration')
     .option('--ignore-gpu-blacklist', 'allow WebGl apps to work on non supported graphics cards')
     .option('--enable-es3-apis', 'force activation of WebGl 2.0')
     .option('--insecure', 'enable loading of insecure content, defaults to false')

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -38,6 +38,7 @@ export default function (inpOptions) {
     fastQuit: inpOptions.fastQuit || false,
     userAgent: inpOptions.userAgent,
     ignoreCertificate: inpOptions.ignoreCertificate || false,
+    disableGpu: inpOptions.disableGpu || false,
     ignoreGpuBlacklist: inpOptions.ignoreGpuBlacklist || false,
     enableEs3Apis: inpOptions.enableEs3Apis || false,
     insecure: inpOptions.insecure || false,


### PR DESCRIPTION
This change closes #364 by adding a `--disable-gpu` flag to nativefier which causes the built app to call `app.disableHardwareAcceleration()` at startup.