### PR TITLE
FIX #573: Unset options.icon if input cannot be converted

### DIFF
--- a/src/build/iconBuild.js
+++ b/src/build/iconBuild.js
@@ -96,6 +96,7 @@ function iconBuild(inpOptions, callback) {
     })
     .catch((error) => {
       log.warn('Skipping icon conversion to .icns', error);
+      options.icon = undefined;
       returnCallback();
     });
 }


### PR DESCRIPTION
This fixes #573 by allowing the build to continue without errors after the icon conversion fails.