### PR TITLE
FIX #590: Ensure secondary windows have the same behaviors as the mainWindow

### DIFF
--- a/app/src/components/contextMenu/contextMenu.js
+++ b/app/src/components/contextMenu/contextMenu.js
@@ -1,7 +1,7 @@
-import { shell, BrowserWindow } from 'electron';
+import { shell } from 'electron';
 import contextMenu from 'electron-context-menu';
 
-function initContextMenu() {
+function initContextMenu(createNewWindow) {
   contextMenu({
     prepend: (params) => {
       const items = [];
@@ -15,7 +15,7 @@ function initContextMenu() {
         items.push({
           label: 'Open Link in New Window',
           click: () => {
-            new BrowserWindow().loadURL(params.linkURL);
+            createNewWindow(params.linkURL);
           },
         });
       }


### PR DESCRIPTION
As described in #590, new windows are not being configured properly. This change refactors window creation so that a common base set of window behaviors can be shared between the mainWindow and new windows that are created.