### PR TITLE
Change incorrect guest property to newGuest

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -199,7 +199,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
       return;
     }
     // eslint-disable-next-line no-param-reassign
-    event.guest = createNewWindow(urlToGo);
+    event.newGuest = createNewWindow(urlToGo);
   };
 
   const sendParamsOnDidFinishLoad = (window) => {


### PR DESCRIPTION
This fixes the issue where Gmail complains that new window creation was prevented by a popup blocker.