### PR TITLE
Fix sites that use about:blank redirect technique

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -185,6 +185,10 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
 
   const onNewWindow = (event, urlToGo, _, disposition) => {
     event.preventDefault();
+    if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
+      shell.openExternal(urlToGo);
+      return;
+    }
     if (nativeTabsSupported()) {
       if (disposition === 'background-tab') {
         createNewTab(urlToGo, false);
@@ -193,10 +197,6 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         createNewTab(urlToGo, true);
         return;
       }
-    }
-    if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
-      shell.openExternal(urlToGo);
-      return;
     }
     // eslint-disable-next-line no-param-reassign
     event.newGuest = createNewWindow(urlToGo);

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -216,6 +216,16 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     maybeInjectCss(window);
     sendParamsOnDidFinishLoad(window);
     window.webContents.on('new-window', onNewWindow);
+    if (url === 'about:blank') {
+      window.hide();
+      window.webContents.once('did-stop-loading', () => {
+        if (window.webContents.getURL() === 'about:blank') {
+          window.close();
+        } else {
+          window.show();
+        }
+      });
+    }
     window.loadURL(url);
     return window;
   };

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -19,6 +19,10 @@ function isWindows() {
 }
 
 function linkIsInternal(currentUrl, newUrl, internalUrlRegex) {
+  if (newUrl === 'about:blank') {
+    return true;
+  }
+
   if (internalUrlRegex) {
     const regex = RegExp(internalUrlRegex);
     return regex.test(newUrl);


### PR DESCRIPTION
When you open some links with Google Calendar, instead of opening the link directly, the site opens a new window with the location 'about:blank' and then sets the new window's document content to include a refresh directive to open the actual link. This change causes the 'about:blank' links to be handled internally so that the technique can actually work.