### PR TITLE
Force all external links to be opened externally

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -217,22 +217,17 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         event.newGuest = newGuest;
       }
     };
-    if (nativeTabsSupported()) {
-      if (disposition === 'background-tab') {
-        const newTab = createNewTab(urlToGo, false);
-        preventDefault(newTab);
-        return;
-      } else if (disposition === 'foreground-tab') {
-        const newTab = createNewTab(urlToGo, true);
-        preventDefault(newTab);
-        return;
-      }
-    }
     if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
       shell.openExternal(urlToGo);
       preventDefault();
-      // eslint-disable-next-line no-useless-return
-      return;
+    } else if (nativeTabsSupported()) {
+      if (disposition === 'background-tab') {
+        const newTab = createNewTab(urlToGo, false);
+        preventDefault(newTab);
+      } else if (disposition === 'foreground-tab') {
+        const newTab = createNewTab(urlToGo, true);
+        preventDefault(newTab);
+      }
     }
   };
 

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { BrowserWindow, shell, ipcMain, dialog } from 'electron';
 import windowStateKeeper from 'electron-window-state';
+import mainWindowHelpers from './mainWindowHelpers';
 import helpers from './../../helpers/helpers';
 import createMenu from './../menu/menu';
 import initContextMenu from './../contextMenu/contextMenu';
@@ -14,6 +15,8 @@ const {
   getAppIcon,
   nativeTabsSupported,
 } = helpers;
+
+const { onNewWindowHelper } = mainWindowHelpers;
 
 const ZOOM_INTERVAL = 0.1;
 
@@ -230,21 +233,17 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         event.newGuest = newGuest;
       }
     };
-    if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
-      shell.openExternal(urlToGo);
-      preventDefault();
-    } else if (urlToGo === 'about:blank') {
-      const newWindow = createAboutBlankWindow();
-      preventDefault(newWindow);
-    } else if (nativeTabsSupported()) {
-      if (disposition === 'background-tab') {
-        const newTab = createNewTab(urlToGo, false);
-        preventDefault(newTab);
-      } else if (disposition === 'foreground-tab') {
-        const newTab = createNewTab(urlToGo, true);
-        preventDefault(newTab);
-      }
-    }
+    onNewWindowHelper(
+      urlToGo,
+      disposition,
+      options.targetUrl,
+      options.internalUrls,
+      preventDefault,
+      shell.openExternal,
+      createAboutBlankWindow,
+      nativeTabsSupported,
+      createNewTab,
+    );
   };
 
   const sendParamsOnDidFinishLoad = (window) => {

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -198,6 +198,13 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     });
   };
 
+  const onWillNavigate = (event, urlToGo) => {
+    if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
+      event.preventDefault();
+      shell.openExternal(urlToGo);
+    }
+  };
+
   let createNewWindow;
 
   const createNewTab = (url, foreground) => {
@@ -260,6 +267,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     maybeInjectCss(window);
     sendParamsOnDidFinishLoad(window);
     window.webContents.on('new-window', onNewWindow);
+    window.webContents.on('will-navigate', onWillNavigate);
     window.loadURL(url);
     return window;
   };
@@ -316,6 +324,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   }
 
   mainWindow.webContents.on('new-window', onNewWindow);
+  mainWindow.webContents.on('will-navigate', onWillNavigate);
 
   mainWindow.loadURL(options.targetUrl);
 

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -209,6 +209,19 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     return undefined;
   };
 
+  const createAboutBlankWindow = () => {
+    const window = createNewWindow('about:blank');
+    window.hide();
+    window.webContents.once('did-stop-loading', () => {
+      if (window.webContents.getURL() === 'about:blank') {
+        window.close();
+      } else {
+        window.show();
+      }
+    });
+    return window;
+  };
+
   const onNewWindow = (event, urlToGo, _, disposition) => {
     const preventDefault = (newGuest) => {
       event.preventDefault();
@@ -220,6 +233,9 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
       shell.openExternal(urlToGo);
       preventDefault();
+    } else if (urlToGo === 'about:blank') {
+      const newWindow = createAboutBlankWindow();
+      preventDefault(newWindow);
     } else if (nativeTabsSupported()) {
       if (disposition === 'background-tab') {
         const newTab = createNewTab(urlToGo, false);

--- a/app/src/components/mainWindow/mainWindowHelpers.js
+++ b/app/src/components/mainWindow/mainWindowHelpers.js
@@ -1,0 +1,33 @@
+import helpers from './../../helpers/helpers';
+
+const { linkIsInternal } = helpers;
+
+function onNewWindowHelper(
+  urlToGo,
+  disposition,
+  targetUrl,
+  internalUrls,
+  preventDefault,
+  openExternal,
+  createAboutBlankWindow,
+  nativeTabsSupported,
+  createNewTab,
+) {
+  if (!linkIsInternal(targetUrl, urlToGo, internalUrls)) {
+    openExternal(urlToGo);
+    preventDefault();
+  } else if (urlToGo === 'about:blank') {
+    const newWindow = createAboutBlankWindow();
+    preventDefault(newWindow);
+  } else if (nativeTabsSupported()) {
+    if (disposition === 'background-tab') {
+      const newTab = createNewTab(urlToGo, false);
+      preventDefault(newTab);
+    } else if (disposition === 'foreground-tab') {
+      const newTab = createNewTab(urlToGo, true);
+      preventDefault(newTab);
+    }
+  }
+}
+
+export default { onNewWindowHelper };

--- a/app/src/components/mainWindow/mainWindowHelpers.test.js
+++ b/app/src/components/mainWindow/mainWindowHelpers.test.js
@@ -1,0 +1,168 @@
+import mainWindowHelpers from './mainWindowHelpers';
+
+const { onNewWindowHelper } = mainWindowHelpers;
+
+const originalUrl = 'https://medium.com/';
+const internalUrl = 'https://medium.com/topics/technology';
+const externalUrl = 'https://www.wikipedia.org/wiki/Electron';
+const foregroundDisposition = 'foreground-tab';
+const backgroundDisposition = 'background-tab';
+
+const nativeTabsSupported = () => true;
+const nativeTabsNotSupported = () => false;
+
+test('internal urls should not be handled', () => {
+  const preventDefault = jest.fn();
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  onNewWindowHelper(
+    internalUrl,
+    undefined,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsNotSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(0);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(0);
+  expect(createNewTab.mock.calls.length).toBe(0);
+  expect(preventDefault.mock.calls.length).toBe(0);
+});
+
+test('external urls should be opened externally', () => {
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  const preventDefault = jest.fn();
+  onNewWindowHelper(
+    externalUrl,
+    undefined,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsNotSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(1);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(0);
+  expect(createNewTab.mock.calls.length).toBe(0);
+  expect(preventDefault.mock.calls.length).toBe(1);
+});
+
+test('tab disposition should be ignored if tabs are not enabled', () => {
+  const preventDefault = jest.fn();
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  onNewWindowHelper(
+    internalUrl,
+    foregroundDisposition,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsNotSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(0);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(0);
+  expect(createNewTab.mock.calls.length).toBe(0);
+  expect(preventDefault.mock.calls.length).toBe(0);
+});
+
+test('tab disposition should be ignored if url is external', () => {
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  const preventDefault = jest.fn();
+  onNewWindowHelper(
+    externalUrl,
+    foregroundDisposition,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(1);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(0);
+  expect(createNewTab.mock.calls.length).toBe(0);
+  expect(preventDefault.mock.calls.length).toBe(1);
+});
+
+test('foreground tabs with internal urls should be opened in the foreground', () => {
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  const preventDefault = jest.fn();
+  onNewWindowHelper(
+    internalUrl,
+    foregroundDisposition,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(0);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(0);
+  expect(createNewTab.mock.calls.length).toBe(1);
+  expect(createNewTab.mock.calls[0][1]).toBe(true);
+  expect(preventDefault.mock.calls.length).toBe(1);
+});
+
+test('background tabs with internal urls should be opened in background tabs', () => {
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  const preventDefault = jest.fn();
+  onNewWindowHelper(
+    internalUrl,
+    backgroundDisposition,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(0);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(0);
+  expect(createNewTab.mock.calls.length).toBe(1);
+  expect(createNewTab.mock.calls[0][1]).toBe(false);
+  expect(preventDefault.mock.calls.length).toBe(1);
+});
+
+test('about:blank urls should be handled', () => {
+  const preventDefault = jest.fn();
+  const openExternal = jest.fn();
+  const createAboutBlankWindow = jest.fn();
+  const createNewTab = jest.fn();
+  onNewWindowHelper(
+    'about:blank',
+    undefined,
+    originalUrl,
+    undefined,
+    preventDefault,
+    openExternal,
+    createAboutBlankWindow,
+    nativeTabsNotSupported,
+    createNewTab,
+  );
+  expect(openExternal.mock.calls.length).toBe(0);
+  expect(createAboutBlankWindow.mock.calls.length).toBe(1);
+  expect(createNewTab.mock.calls.length).toBe(0);
+  expect(preventDefault.mock.calls.length).toBe(1);
+});

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -19,6 +19,10 @@ function isWindows() {
 }
 
 function linkIsInternal(currentUrl, newUrl, internalUrlRegex) {
+  if (newUrl === 'about:blank') {
+    return true;
+  }
+
   if (internalUrlRegex) {
     const regex = RegExp(internalUrlRegex);
     return regex.test(newUrl);

--- a/app/src/helpers/helpers.test.js
+++ b/app/src/helpers/helpers.test.js
@@ -1,0 +1,30 @@
+import helpers from './helpers';
+
+const { linkIsInternal } = helpers;
+
+const internalUrl = 'https://medium.com/';
+const internalUrlSubPath = 'topic/technology';
+const externalUrl = 'https://www.wikipedia.org/wiki/Electron';
+const wildcardRegex = /.*/;
+
+test('the original url should be internal', () => {
+  expect(linkIsInternal(internalUrl, internalUrl, undefined)).toEqual(true);
+});
+
+test('sub-paths of the original url should be internal', () => {
+  expect(
+    linkIsInternal(internalUrl, internalUrl + internalUrlSubPath, undefined),
+  ).toEqual(true);
+});
+
+test("'about:blank' should be internal", () => {
+  expect(linkIsInternal(internalUrl, 'about:blank', undefined)).toEqual(true);
+});
+
+test('urls from different sites should not be internal', () => {
+  expect(linkIsInternal(internalUrl, externalUrl, undefined)).toEqual(false);
+});
+
+test('all urls should be internal with wildcard regex', () => {
+  expect(linkIsInternal(internalUrl, externalUrl, wildcardRegex)).toEqual(true);
+});


### PR DESCRIPTION
This PR makes it so any navigation to an external link results in the link being opened in an external browser. The current behavior is to only do so for links with `target="_blank"`, or those opened via `window.open()`.

This PR also includes a fix for handling the 'about:blank' redirect technique that Google Calendar uses for some external links.

Without this change, the links in Google Calendar do nothing when clicked, because `about:blank` is passed to `shell.openExternal()`, which does nothing with it.

The 'about:blank' fix consists of multiple changes:

* The `linkIsInternal()` function has been updated to treat `about:blank` links as internal so that the redirect technique can work at all. However, while this works, the redirect itself causes another window to be opened (in the external browser, or in a new tab if tabs are enabled), leaving behind a blank, useless window in the nativefier app.

* Tests have been added for `linkIsInternal()`

* The `about:blank` window is hidden until the redirect occurs, at which point it closes the window, thereby avoiding the problem of the blank, useless window being left behind.

* The `onNewWindow()` function has been refactored to make it testable, and tests have been added.