### PR TITLE
Only override the default window opening behavior when necessary

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -210,22 +210,30 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   };
 
   const onNewWindow = (event, urlToGo, _, disposition) => {
-    event.preventDefault();
+    const preventDefault = (newGuest) => {
+      event.preventDefault();
+      if (newGuest) {
+        // eslint-disable-next-line no-param-reassign
+        event.newGuest = newGuest;
+      }
+    };
     if (nativeTabsSupported()) {
       if (disposition === 'background-tab') {
-        createNewTab(urlToGo, false);
+        const newTab = createNewTab(urlToGo, false);
+        preventDefault(newTab);
         return;
       } else if (disposition === 'foreground-tab') {
-        createNewTab(urlToGo, true);
+        const newTab = createNewTab(urlToGo, true);
+        preventDefault(newTab);
         return;
       }
     }
     if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
       shell.openExternal(urlToGo);
+      preventDefault();
+      // eslint-disable-next-line no-useless-return
       return;
     }
-    // eslint-disable-next-line no-param-reassign
-    event.newGuest = createNewWindow(urlToGo);
   };
 
   const sendParamsOnDidFinishLoad = (window) => {


### PR DESCRIPTION
As part of #591, all window creation was routed through a createNewWindow function.  That change introduced the regression reported in #616 in which popup windows could not communicate with their parent windows. This change reverts that behavior for windows opened via JavaScript (that aren't being opened as tabs and aren't being opened in external browsers), thereby fixing the reported regression.