### PR TITLE
Always open external links externally

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -217,22 +217,17 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         event.newGuest = newGuest;
       }
     };
-    if (nativeTabsSupported()) {
-      if (disposition === 'background-tab') {
-        const newTab = createNewTab(urlToGo, false);
-        preventDefault(newTab);
-        return;
-      } else if (disposition === 'foreground-tab') {
-        const newTab = createNewTab(urlToGo, true);
-        preventDefault(newTab);
-        return;
-      }
-    }
     if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
       shell.openExternal(urlToGo);
       preventDefault();
-      // eslint-disable-next-line no-useless-return
-      return;
+    } else if (nativeTabsSupported()) {
+      if (disposition === 'background-tab') {
+        const newTab = createNewTab(urlToGo, false);
+        preventDefault(newTab);
+      } else if (disposition === 'foreground-tab') {
+        const newTab = createNewTab(urlToGo, true);
+        preventDefault(newTab);
+      }
     }
   };
 


### PR DESCRIPTION
The tab feature introduced by #579 included a change that checks the `disposition` parameter and conditionally creates tabs, and that check was placed prior to the check to see if the URL is internal. This change moves the `linkIsInternal()` check earlier so that external links are always opened externally, regardless of disposition.

This change fixes #621.