### PR TITLE
Force all external links to be opened externally

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -195,6 +195,13 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     });
   };
 
+  const onWillNavigate = (event, urlToGo) => {
+    if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {
+      event.preventDefault();
+      shell.openExternal(urlToGo);
+    }
+  };
+
   let createNewWindow;
 
   const createNewTab = (url, foreground) => {
@@ -250,6 +257,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     maybeInjectCss(window);
     sendParamsOnDidFinishLoad(window);
     window.webContents.on('new-window', onNewWindow);
+    window.webContents.on('will-navigate', onWillNavigate);
     window.loadURL(url);
     return window;
   };
@@ -306,6 +314,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   }
 
   mainWindow.webContents.on('new-window', onNewWindow);
+  mainWindow.webContents.on('will-navigate', onWillNavigate);
 
   mainWindow.loadURL(options.targetUrl);
 


### PR DESCRIPTION
This PR makes it so any navigation to an external link results in the link being opened in an external browser. The current behavior is to only do so for links with target="_blank", or those opened via window.open().
