### PR TITLE
Make the counter regexp allow punctuation

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -14,6 +14,7 @@ const {
   shouldInjectCss,
   getAppIcon,
   nativeTabsSupported,
+  getCounterValue,
 } = helpers;
 
 const { onNewWindowHelper } = mainWindowHelpers;
@@ -303,10 +304,9 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
 
   if (options.counter) {
     mainWindow.on('page-title-updated', (e, title) => {
-      const itemCountRegex = /[([{](\d*?)\+?[}\])]/;
-      const match = itemCountRegex.exec(title);
-      if (match) {
-        setDockBadge(match[1], options.bounce);
+      const counterValue = getCounterValue(title);
+      if (counterValue) {
+        setDockBadge(counterValue, options.bounce);
       } else {
         setDockBadge('');
       }

--- a/app/src/components/trayIcon/trayIcon.js
+++ b/app/src/components/trayIcon/trayIcon.js
@@ -2,7 +2,7 @@ import helpers from './../../helpers/helpers';
 
 const { app, Tray, Menu, ipcMain, nativeImage } = require('electron');
 
-const { getAppIcon } = helpers;
+const { getAppIcon, getCounterValue } = helpers;
 
 /**
  *
@@ -49,10 +49,9 @@ function createTrayIcon(inpOptions, mainWindow) {
 
     if (options.counter) {
       mainWindow.on('page-title-updated', (e, title) => {
-        const itemCountRegex = /[([{](\d*?)\+?[}\])]/;
-        const match = itemCountRegex.exec(title);
-        if (match) {
-          appIcon.setToolTip(`(${match[1]})  ${options.name}`);
+        const counterValue = getCounterValue(title);
+        if (counterValue) {
+          appIcon.setToolTip(`(${counterValue})  ${options.name}`);
         } else {
           appIcon.setToolTip(options.name);
         }

--- a/app/src/helpers/helpers.js
+++ b/app/src/helpers/helpers.js
@@ -67,6 +67,12 @@ function nativeTabsSupported() {
   return isOSX();
 }
 
+function getCounterValue(title) {
+  const itemCountRegex = /[([{]([\d.,]*)\+?[}\])]/;
+  const match = itemCountRegex.exec(title);
+  return match ? match[1] : undefined;
+}
+
 export default {
   isOSX,
   isLinux,
@@ -77,4 +83,5 @@ export default {
   shouldInjectCss,
   getAppIcon,
   nativeTabsSupported,
+  getCounterValue,
 };

--- a/app/src/helpers/helpers.test.js
+++ b/app/src/helpers/helpers.test.js
@@ -1,6 +1,6 @@
 import helpers from './helpers';
 
-const { linkIsInternal } = helpers;
+const { linkIsInternal, getCounterValue } = helpers;
 
 const internalUrl = 'https://medium.com/';
 const internalUrlSubPath = 'topic/technology';
@@ -27,4 +27,20 @@ test('urls from different sites should not be internal', () => {
 
 test('all urls should be internal with wildcard regex', () => {
   expect(linkIsInternal(internalUrl, externalUrl, wildcardRegex)).toEqual(true);
+});
+
+const smallCounterTitle = 'Inbox (11) - nobody@example.com - Gmail';
+const largeCounterTitle = 'Inbox (8,756) - nobody@example.com - Gmail';
+const noCounterTitle = 'Inbox - nobody@example.com - Gmail';
+
+test('getCounterValue should return undefined for titles without counter numbers', () => {
+  expect(getCounterValue(noCounterTitle)).toEqual(undefined);
+});
+
+test('getCounterValue should return a string for small counter numbers in the title', () => {
+  expect(getCounterValue(smallCounterTitle)).toEqual('11');
+});
+
+test('getCounterValue should return a string for large counter numbers in the title', () => {
+  expect(getCounterValue(largeCounterTitle)).toEqual('8,756');
 });


### PR DESCRIPTION
When using an app such as Gmail, the unread count is included in the title, and the --counter feature displays that number on the dock icon. However, when the number is larger than 999, it includes commas in the number (e.g. "1,000"), and the number is no longer displayed on the dock icon, because the regular expression used to detect the counter value does not permit punctuation.

This change modifies the regular expression used to match the counter value to permit "." and ",".