### PR TITLE
Add Unix/Mac-conventional `-v` version flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -37,7 +37,7 @@ function checkInternet() {
 
 if (require.main === module) {
   program
-    .version(packageJson.version)
+    .version(packageJson.version, '--version, -V, -v')
     .arguments('<targetUrl> [dest]')
     .action((targetUrl, appDir) => {
       program.targetUrl = targetUrl;


### PR DESCRIPTION
Most Unix-based command line utilities respond to a _lowercase_ `-v` flag which outputs the current version. Adding that as an alias here in addition to the already present `--version` and `-V` flags :)