### PR TITLE
Make `getCurrentUrl` actually return something

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -129,8 +129,9 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   const withFocusedWindow = (block) => {
     const focusedWindow = BrowserWindow.getFocusedWindow();
     if (focusedWindow) {
-      block(focusedWindow);
+      return block(focusedWindow);
     }
+    return undefined;
   };
 
   const adjustWindowZoom = (window, adjustment) => {
@@ -194,11 +195,8 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     });
   };
 
-  const getCurrentUrl = () => {
-    withFocusedWindow((focusedWindow) => {
-      focusedWindow.webContents.getURL();
-    });
-  };
+  const getCurrentUrl = () =>
+    withFocusedWindow((focusedWindow) => focusedWindow.webContents.getURL());
 
   const onWillNavigate = (event, urlToGo) => {
     if (!linkIsInternal(options.targetUrl, urlToGo, options.internalUrls)) {


### PR DESCRIPTION
When the `getCurrentUrl` function was refactored to make use of the `withFocusedWindow` function in ac99c6424d7326ad7d1da86922866e6776ce3220, it stopped returning a value and broke the "Copy Current URL" feature (#633).

This change restores the original behavior of the getCurrentURL function and makes the "Copy Current URL" feature functional again.