### PR TITLE
Restore application window on notification click

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -322,6 +322,12 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     });
   }
 
+  ipcMain.on('notification-click', () => {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+  });
+
   mainWindow.webContents.on('new-window', onNewWindow);
   mainWindow.webContents.on('will-navigate', onWillNavigate);
 

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -323,9 +323,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   }
 
   ipcMain.on('notification-click', () => {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore();
-    }
+    mainWindow.show();
   });
 
   mainWindow.webContents.on('new-window', onNewWindow);


### PR DESCRIPTION
There currently is an issue where the nativefied application does not respond to clicking on a desktop notification. You would expect it to restore and focus its window, but that doesn't work if:

- The window is minimized
- There is no open window (macOS)

See #221 and possibly #396.

This PR fixes that by adding a click handler to each notification. When clicking the notification the Electron app restores and focuses the main window using BrowserWindow.show(). This seems to handle both cases (restore minimized window / open new window, then focus window).