### PR TITLE
Remove mention to older badge option in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -190,7 +190,7 @@ To retrieve the `.icns` file from the downloaded file, extract it first and pres
 --counter
 ```
 
-Use a counter that persists even with window focus for the application badge for sites that use an "(X)" format counter in the page title (i.e. Gmail).  Same limitations as the badge option (above).
+Use a counter that persists even with window focus for the application badge for sites that use an "(X)" format counter in the page title (i.e. Gmail).
 
 #### [bounce]
 


### PR DESCRIPTION
The `--counter` option mentioned a _badge option_, which doesn't appear in the docs. This change removes this as it is not relevant in the context.