### PR TITLE
add tray icon cli option to support overriding the tray icon #668

### DIFF
--- a/app/src/components/trayIcon/trayIcon.js
+++ b/app/src/components/trayIcon/trayIcon.js
@@ -14,7 +14,7 @@ function createTrayIcon(inpOptions, mainWindow) {
   const options = Object.assign({}, inpOptions);
 
   if (options.tray) {
-    const iconPath = getAppIcon();
+    const iconPath = options.trayIcon ? options.trayIcon : getAppIcon();
     const nimage = nativeImage.createFromPath(iconPath);
     const appIcon = new Tray(nimage);
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -508,6 +508,14 @@ Prevents application from being run multiple times. If such an attempt occurs th
 
 Application will stay as an icon in the system tray. Prevents application from being closed from clicking the window close button.
 
+#### [tray-icon]
+
+```
+--tray-icon
+```
+
+Allows applications to specify a specific path to a tray icon when used with tray mode.
+
 #### [basic-auth-username]
 
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -192,6 +192,7 @@ if (require.main === module) {
       parseJson,
     )
     .option('--tray', 'allow app to stay in system tray')
+    .option('--tray-icon', 'allows the app to specify a tray icon to use')
     .option('--basic-auth-username <value>', 'basic http(s) auth username')
     .option('--basic-auth-password <value>', 'basic http(s) auth password')
     .option('--always-on-top', 'enable always on top window')


### PR DESCRIPTION
This should allow for a resolution to #668 so the user can add a specific tray-icon to replace the default getAppIcon as outlined in the conversation from @dvbii and @kikobeats:

```
Kikobeats (Kiko Beats) on Sep 7 
@dvbii feeling you're right, but I put an image there and doesn't work.

Maybe the image needs to have a specific dimension?

On the other hand, why not make this file configurable as flag?

nativefier -n Twitter --fast-quit --single-instance --tray twitter.png "https://m.twitter.com"
 @dvbii
 
dvbii (David vanBlaricom II) on Sep 7 
Yes, I had to make the image 90pixels x 90 pixels. Then had to name it icon.png. Definitely agree it should either be a flag or at least add to the function that makes the icons to auto create this icon.png and put it where it needs to go. Or change the reference to where it is looking for it.
```