### PR TITLE
Fix Electron 3 CSS injection (#703)

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -46,17 +46,17 @@ function maybeInjectCss(browserWindow) {
 
   browserWindow.webContents.on('did-finish-load', () => {
     // remove the injection of css the moment the page is loaded
-    browserWindow.webContents.removeListener(
-      'did-get-response-details',
-      injectCss,
-    );
+    browserWindow.webContents.session.webRequest.onHeadersReceived(null);
   });
 
   // on every page navigation inject the css
   browserWindow.webContents.on('did-navigate', () => {
-    // we have to inject the css in did-get-response-details to prevent the fouc
+    // we have to inject the css in onHeadersReceived to prevent the fouc
     // will run multiple times
-    browserWindow.webContents.on('did-get-response-details', injectCss);
+    browserWindow.webContents.session.webRequest.onHeadersReceived(function(details, callback) {
+        injectCss();
+        callback({cancel: false, responseHeaders: details.responseHeaders});
+    });
   });
 }
 


### PR DESCRIPTION
A very basic change to fix #703. I only changed the deprecated `did-get-response-details` event to the recommended alternative: `webRequest.onHeadersReceived`.

All tests that I done with navigation and prevention of FOUC passed using the same command of the issue (`nativefier "https://www.w3schools.com" --inject ./main.css --overwrite`).