### PR TITLE
Fix the appBundleId for MacOS build to give out the custom BundleID to the electron-packager

### DIFF
--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -63,6 +63,7 @@ export default function(inpOptions) {
     buildVersion: inpOptions.buildVersion,
     appCopyright: inpOptions.appCopyright,
     versionString: inpOptions.versionString,
+    appBundleId: inpOptions.appBundleId,
     win32metadata: inpOptions.win32metadata || {
       ProductName: inpOptions.name,
       InternalName: inpOptions.name,


### PR DESCRIPTION
Currently the natifier MacOS package generates package with default `com.electron.appName`

Fix for [712](https://github.com/jiahaog/nativefier/issues/712)

Fix to support below
https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#appbundleid 

