### PR TITLE
proof-of-concept for adding chrome extensions

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -3,6 +3,9 @@ import fs from 'fs';
 import path from 'path';
 import { app, crashReporter, globalShortcut } from 'electron';
 import electronDownload from 'electron-dl';
+import installExtension, {
+  REACT_DEVELOPER_TOOLS,
+} from 'electron-devtools-installer';
 
 import createLoginWindow from './components/login/loginWindow';
 import createMainWindow from './components/mainWindow/mainWindow';
@@ -134,6 +137,16 @@ app.on('ready', () => {
     });
   }
 });
+
+app.on('ready', () => {
+  installExtension(REACT_DEVELOPER_TOOLS)
+    .then((name) => {
+      console.log("Successfully installed", name)
+    })
+    .catch((err) =>{
+      console.log('An error occurred when trying to add extention: ', err)
+    });
+})
 
 app.on('new-window-for-tab', () => {
   mainWindow.emit('new-tab');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-polyfill": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
     "commander": "^2.14.0",
+    "electron-devtools-installer": "^2.2.4",
     "electron-packager": "^12.0.1",
     "gitcloud": "^0.1.0",
     "hasbin": "^1.2.3",


### PR DESCRIPTION
I'm working on a PR to add the feature in https://github.com/jiahaog/nativefier/issues/207 

The code in this branch adds react dev tools as a test	😀

## How to test
- clone this repo and cd into it
- run `npm link` to set up symlink to the current directory
- run `npm link nativefier` in the repo where you would like to test this
- run nativefier 
- open up the new packaged app 
- open up dev tools
- see that there is a new React app

## TODO
- [ ] I think there should probably a be a command line argument for specifying any extension you want

## Feedback requested
- I'll add code comments with my questions 👍
- Should there be unit tests associated with this change?