### PR TITLE
Address CSS & JavaScript injection issues (#703, #731)

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -55,10 +55,10 @@ function maybeInjectCss(browserWindow) {
 
   // on every page navigation inject the css
   browserWindow.webContents.on('did-navigate', () => {
-    // we have to inject the css in onHeadersReceived to prevent the fouc
-    // will run multiple times
+    // we have to inject the css in onHeadersReceived so they're early enough
+    // will run multiple times, so did-finish-load will remove this handler
     browserWindow.webContents.session.webRequest.onHeadersReceived(
-      null,
+      [], // Pass an empty filter list; null will not match _any_ urls
       onHeadersReceived,
     );
   });

--- a/app/src/static/preload.js
+++ b/app/src/static/preload.js
@@ -1,9 +1,22 @@
 /**
  Preload file that will be executed in the renderer process
  */
-import { ipcRenderer } from 'electron';
-import path from 'path';
-import fs from 'fs';
+
+/**
+ * Note: This needs to be attached prior to the imports, as the they will delay
+ * the attachment till after the event has been raised.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  // Due to the early attachment, this triggers a linter error
+  // because it's not yet been defined.
+  // eslint-disable-next-line no-use-before-define
+  injectScripts();
+});
+
+// Disable imports being first due to the above event attachment
+import { ipcRenderer } from 'electron'; // eslint-disable-line import/first
+import path from 'path'; // eslint-disable-line import/first
+import fs from 'fs'; // eslint-disable-line import/first
 
 const INJECT_JS_PATH = path.join(__dirname, '../../', 'inject/inject.js');
 const log = require('loglevel');
@@ -48,10 +61,6 @@ function notifyNotificationClick() {
 }
 
 setNotificationCallback(notifyNotificationCreate, notifyNotificationClick);
-
-document.addEventListener('DOMContentLoaded', () => {
-  injectScripts();
-});
 
 ipcRenderer.on('params', (event, message) => {
   const appArgs = JSON.parse(message);

--- a/docs/api.md
+++ b/docs/api.md
@@ -396,6 +396,8 @@ Forces the maximum disk space to be used by the disk cache. Value is given in by
 
 Allows you to inject a javascript or css file. This command can be run multiple times to inject the files.
 
+_Note:_ The javascript file is loaded _after_ `DOMContentLoaded`, so you can assume the DOM is complete & available.
+
 Example:
 
 ```bash


### PR DESCRIPTION
These commits address #703, #731 by fixing the two core issues:
1. #703, was caused by null filters being passed to `onHeadersReceived`. Passing `[]` resolves the issue
2. #731, was caused by a timing issue of when `DOMContentLoaded` was attached vs raised.

Each commit contains the full details. Also updates `api.md` with some extra context about when injected JavaScript is inserted