### PR TITLE
Allow spaces in folder names

### DIFF
--- a/src/helpers/convertToIcns.js
+++ b/src/helpers/convertToIcns.js
@@ -27,7 +27,7 @@ function convertToIcns(pngSrc, icnsDest, callback) {
   }
 
   shell.exec(
-    `${PNG_TO_ICNS_BIN_PATH} ${pngSrc} ${icnsDest}`,
+    `"${PNG_TO_ICNS_BIN_PATH}" "${pngSrc}" "${icnsDest}"`,
     { silent: true },
     (exitCode, stdOut, stdError) => {
       if (stdOut.includes('icon.iconset:error') || exitCode) {

--- a/src/helpers/iconShellHelpers.js
+++ b/src/helpers/iconShellHelpers.js
@@ -26,7 +26,7 @@ function iconShellHelper(shellScriptPath, icoSrc, dest) {
       reject(new Error('OSX or Linux is required'));
       return;
     }
-    
+
     shell.exec(
       `"${shellScriptPath}" "${icoSrc}" "${dest}"`,
       { silent: true },

--- a/src/helpers/iconShellHelpers.js
+++ b/src/helpers/iconShellHelpers.js
@@ -26,9 +26,9 @@ function iconShellHelper(shellScriptPath, icoSrc, dest) {
       reject(new Error('OSX or Linux is required'));
       return;
     }
-
+    
     shell.exec(
-      `${shellScriptPath} ${icoSrc} ${dest}`,
+      `"${shellScriptPath}" "${icoSrc}" "${dest}"`,
       { silent: true },
       (exitCode, stdOut, stdError) => {
         if (exitCode) {


### PR DESCRIPTION
Currently having spaces in folders causes the icon conversion to crash. This PR fixes the issue.