### PR TITLE
Support packaging nativefier applications into Squirrel-based installers

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "electron-context-menu": "^0.10.0",
     "electron-dl": "^1.10.0",
+    "electron-squirrel-startup": "^1.0.0",
     "electron-window-state": "^4.1.1",
     "loglevel": "^1.5.1",
     "source-map-support": "^0.5.0",

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -10,6 +10,13 @@ import createTrayIcon from './components/trayIcon/trayIcon';
 import helpers from './helpers/helpers';
 import inferFlash from './helpers/inferFlash';
 
+const electronSquirrelStartup = require('electron-squirrel-startup');
+
+// Entrypoint for electron-squirrel-startup
+if (electronSquirrelStartup) {
+  app.quit();
+}
+
 const { isOSX } = helpers;
 
 const APP_ARGS_FILE_PATH = path.join(__dirname, '..', 'nativefier.json');

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -12,7 +12,8 @@ import inferFlash from './helpers/inferFlash';
 
 const electronSquirrelStartup = require('electron-squirrel-startup');
 
-// Entrypoint for electron-squirrel-startup
+// Entrypoint for electron-squirrel-startup.
+// See https://github.com/jiahaog/nativefier/pull/744 for sample use case
 if (electronSquirrelStartup) {
   app.quit();
 }


### PR DESCRIPTION
[Squirrel](https://github.com/Squirrel/Squirrel.Windows) is *"an installation and update framework for Windows desktop apps "*.

This PR adds `electron-squirrel-startup`, allowing to package nativefier applications 
into squirrel-based setup installers. Squirrel require this entrypoint to perform
desktop and startup menu creations, without showing the UI on setup launches.

- References: https://github.com/mongodb-js/electron-squirrel-startup

- Resolves `electron-winstaller` and `electron-installer-windows` support of desktop / startup menu shortcuts for nativefier packaged applications.

- The `electron-squirrel-startup` entrypoint has no effect on both Linux and Darwin, only on Windows

- Supporting it directly inside `nativefier` avoids having to "hack" around the existing `main.js`
  and including dependencies from `electron-squirrel-startup` in an intermediate package
  to be included in a third layer for the final installer executable

- The following script based on both `nativefier` and `electron-winstaller` templates
   represents a portable proof of concept for this merge request :

```js
var nativefier = require('nativefier').default;
var electronInstaller = require('electron-winstaller');

var options = {
  name: 'Web WhatsApp',
  targetUrl: 'http://web.whatsapp.com',
  platform: 'windows',
  arch: 'x64',
  version: '0.36.4',
  out: '.',
  overwrite: false,
  asar: false,
  counter: false,
  bounce: false,
  width: 1280,
  height: 800,
  showMenuBar: false,
  fastQuit: false,
  userAgent: 'Mozilla ...',
  ignoreCertificate: false,
  ignoreGpuBlacklist: false,
  enableEs3Apis: false,
  insecure: false,
  honest: false,
  zoom: 1.0,
  singleInstance: false,
  fileDownloadOptions: {
    saveAs: true
  },
  processEnvs: {
    GOOGLE_API_KEY: '<your-google-api-key>'
  }
};

nativefier(options, function(error, appPath) {
  if (error) {
    console.error(error);
    return;
  }
  console.log('App has been nativefied to', appPath);

  resultPromise = electronInstaller.createWindowsInstaller({
    appDirectory: 'Web WhatsApp-win32-x64',
    outputDirectory: './',
    authors: 'Web WhatsApp',
    exe: 'Web WhatsApp.exe'
  });

  resultPromise.then(() => console.log('It worked!'), e => console.log(`No dice: ${e.message}`));
});
```