### PR TITLE
Fix #316: Add --clear-cache flag to cleanup session on start/exit ("incognito" mode)

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -64,6 +64,17 @@ function maybeInjectCss(browserWindow) {
   });
 }
 
+function clearCache(browserWindow, targetUrl = null) {
+  const { session } = browserWindow.webContents;
+  session.clearStorageData(() => {
+    session.clearCache(() => {
+      if (targetUrl) {
+        browserWindow.loadURL(targetUrl);
+      }
+    });
+  });
+}
+
 /**
  *
  * @param {{}} inpOptions AppArgs from nativefier.json
@@ -178,12 +189,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         if (response !== 0) {
           return;
         }
-        const { session } = mainWindow.webContents;
-        session.clearStorageData(() => {
-          session.clearCache(() => {
-            mainWindow.loadURL(options.targetUrl);
-          });
-        });
+        clearCache(mainWindow, options.targetUrl);
       },
     );
   };
@@ -334,6 +340,10 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   mainWindow.webContents.on('new-window', onNewWindow);
   mainWindow.webContents.on('will-navigate', onWillNavigate);
 
+  if (options.clearCache) {
+    clearCache(mainWindow);
+  }
+
   mainWindow.loadURL(options.targetUrl);
 
   mainWindow.on('new-tab', () => createNewTab(options.targetUrl, true));
@@ -350,6 +360,10 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
       );
     }
     maybeHideWindow(mainWindow, event, options.fastQuit, options.tray);
+
+    if (options.clearCache) {
+      clearCache(mainWindow);
+    }
   });
 
   return mainWindow;

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,6 +56,7 @@
     - [[crash-reporter]](#crash-reporter)
     - [[zoom]](#zoom)
     - [[single-instance]](#single-instance)
+    - [[clear-cache]](#clear-cache)
     - [[tray]](#tray)
     - [[basic-auth-username]](#basic-auth-username)
     - [[processEnvs]](#processenvs)
@@ -518,6 +519,14 @@ Sets a default zoom factor to be used when the app is opened, defaults to `1.0`.
 
 Prevents application from being run multiple times. If such an attempt occurs the already running instance is brought to front.
 
+#### [clear-cache]
+
+```
+--clear-cache
+```
+
+Prevents the application from preserving cache between launches.
+
 #### [tray]
 
 ```
@@ -720,6 +729,7 @@ var options = {
     honest: false,
     zoom: 1.0,
     singleInstance: false,
+    clearCache: false,
     fileDownloadOptions: {
       saveAs: true // always show "Save As" dialog
     },

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -44,6 +44,7 @@ function selectAppArgs(options) {
     internalUrls: options.internalUrls,
     crashReporter: options.crashReporter,
     singleInstance: options.singleInstance,
+    clearCache: options.clearCache,
     appCopyright: options.appCopyright,
     appVersion: options.appVersion,
     buildVersion: options.buildVersion,

--- a/src/cli.js
+++ b/src/cli.js
@@ -209,6 +209,10 @@ if (require.main === module) {
       'allow only a single instance of the application',
     )
     .option(
+      '--clear-cache',
+      'prevent the application from preserving cache between launches',
+    )
+    .option(
       '--processEnvs <json-string>',
       'a JSON string of key/value pairs to be set as environment variables before any browser windows are opened.',
       getProcessEnvs,

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -59,6 +59,7 @@ export default function(inpOptions) {
     zoom: inpOptions.zoom || 1.0,
     internalUrls: inpOptions.internalUrls || null,
     singleInstance: inpOptions.singleInstance || false,
+    clearCache: inpOptions.clearCache || false,
     appVersion: inpOptions.appVersion,
     buildVersion: inpOptions.buildVersion,
     appCopyright: inpOptions.appCopyright,


### PR DESCRIPTION
- Add a new `clearCache` option and `--clear-cache` parameter
  to trigger session cleanups upon window launch and close

- Covers the feature request from issue #316 

- Use case example: Forcing authentification / login between sessions without limiting cache size