### PR TITLE
Allow opening external URLs on macOS.

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -348,6 +348,8 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
 
   mainWindow.on('new-tab', () => createNewTab(options.targetUrl, true));
 
+  mainWindow.on('new-tab-with-url', (url) => createNewTab(url, true));
+
   mainWindow.on('close', (event) => {
     if (mainWindow.isFullScreen()) {
       if (nativeTabsSupported()) {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -104,6 +104,10 @@ app.on('activate', (event, hasVisibleWindows) => {
   }
 });
 
+app.on('open-url', (event, url) => {
+  mainWindow.emit('new-tab-with-url', url);
+});
+
 app.on('before-quit', () => {
   // not fired when the close button on the window is clicked
   if (isOSX()) {


### PR DESCRIPTION
This doesn't resolve #405 on all platforms, but does appear to allow opening URLs passed from other applications on macOS. This means that I can click on links in Mail.app for my GitLab issues and have them open in GitLab.app (by using Choosy, as discussed in the issue).