### PR TITLE
Fix crash when launching a second instance using option --single-instance (Fixes #664)

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -127,21 +127,36 @@ if (appArgs.crashReporter) {
   });
 }
 
-app.on('ready', () => {
-  mainWindow = createMainWindow(appArgs, app.quit, setDockBadge);
-  createTrayIcon(appArgs, mainWindow);
+// quit if singleInstance mode and there's already another instance running
+let shouldQuit = appArgs.singleInstance && !app.requestSingleInstanceLock();
+if (shouldQuit) {
+  app.quit();
+} else {
+  app.on('second-instance', (event, commandLine, workingDirectory) => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore()
+      }
+      mainWindow.focus()
+    }
+  });
 
-  // Register global shortcuts
-  if (appArgs.globalShortcuts) {
-    appArgs.globalShortcuts.forEach((shortcut) => {
-      globalShortcut.register(shortcut.key, () => {
-        shortcut.inputEvents.forEach((inputEvent) => {
-          mainWindow.webContents.sendInputEvent(inputEvent);
+  app.on('ready', () => {
+    mainWindow = createMainWindow(appArgs, app.quit, setDockBadge);
+    createTrayIcon(appArgs, mainWindow);
+
+    // Register global shortcuts
+    if (appArgs.globalShortcuts) {
+      appArgs.globalShortcuts.forEach((shortcut) => {
+        globalShortcut.register(shortcut.key, () => {
+          shortcut.inputEvents.forEach((inputEvent) => {
+            mainWindow.webContents.sendInputEvent(inputEvent);
+          });
         });
       });
-    });
-  }
-});
+    }
+  });
+}
 
 app.on('new-window-for-tab', () => {
   mainWindow.emit('new-tab');
@@ -160,24 +175,3 @@ app.on('login', (event, webContents, request, authInfo, callback) => {
     createLoginWindow(callback);
   }
 });
-
-if (appArgs.singleInstance) {
-  const shouldQuit = app.makeSingleInstance(() => {
-    // Someone tried to run a second instance, we should focus our window.
-    if (mainWindow) {
-      if (!mainWindow.isVisible()) {
-        // tray
-        mainWindow.show();
-      }
-      if (mainWindow.isMinimized()) {
-        // minimized
-        mainWindow.restore();
-      }
-      mainWindow.focus();
-    }
-  });
-
-  if (shouldQuit) {
-    app.quit();
-  }
-}

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -128,16 +128,16 @@ if (appArgs.crashReporter) {
 }
 
 // quit if singleInstance mode and there's already another instance running
-let shouldQuit = appArgs.singleInstance && !app.requestSingleInstanceLock();
+const shouldQuit = appArgs.singleInstance && !app.requestSingleInstanceLock();
 if (shouldQuit) {
   app.quit();
 } else {
-  app.on('second-instance', (event, commandLine, workingDirectory) => {
+  app.on('second-instance', () => {
     if (mainWindow) {
       if (mainWindow.isMinimized()) {
-        mainWindow.restore()
+        mainWindow.restore();
       }
-      mainWindow.focus()
+      mainWindow.focus();
     }
   });
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -134,7 +134,12 @@ if (shouldQuit) {
 } else {
   app.on('second-instance', () => {
     if (mainWindow) {
+      if (!mainWindow.isVisible()) {
+        // try
+        mainWindow.show();
+      }
       if (mainWindow.isMinimized()) {
+        // minimized
         mainWindow.restore();
       }
       mainWindow.focus();


### PR DESCRIPTION
Resolve issue #664, exception encountered when using the --single-instance option. This refactors the deprecated call to app.makeSingleInstance(). See https://electronjs.org/docs/all?q=app.requestSingleInstanceLock.
