### PR TITLE
squirrel: resolve .quit() issue with missing ../screen

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -15,7 +15,7 @@ const electronSquirrelStartup = require('electron-squirrel-startup');
 // Entrypoint for electron-squirrel-startup.
 // See https://github.com/jiahaog/nativefier/pull/744 for sample use case
 if (electronSquirrelStartup) {
-  app.quit();
+  app.exit();
 }
 
 const { isOSX } = helpers;


### PR DESCRIPTION
 * As explained in: https://github.com/electron/electron/issues/8862#issuecomment-294303518
    an issue with .quit() exists with a "Cannot find module '../screen'" issue,
    while using the .exit() alternative avoids the issue

* Validated on Windows with the same logic as #744 where the issue recently appeared