### PR TITLE
Support macOS 10.4+ Dark Mode, default to Electron 5.x

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,7 @@
     - [[file-download-options]](#file-download-options)
     - [[always-on-top]](#always-on-top)
     - [[global-shortcuts]](#global-shortcuts)
+    - [[darwin-dark-mode-support]](#darwin-dark-mode-support)
 - [Programmatic API](#programmatic-api)
   - [Addition packaging options for Windows](#addition-packaging-options-for-windows)
     - [[version-string]](#version-string)
@@ -694,6 +695,13 @@ Example `shortcuts.json` for `https://deezer.com` & `https://soundcloud.com` to 
 ]
 ```
 
+#### [darwin-dark-mode-support]
+
+```
+--darwin-dark-mode-support
+```
+
+Enables Dark Mode support on macOS 10.4+.
 
 ## Programmatic API
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-polyfill": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
     "commander": "^2.14.0",
-    "electron-packager": "^12.0.1",
+    "electron-packager": "^12.2.0",
     "gitcloud": "^0.1.0",
     "hasbin": "^1.2.3",
     "lodash": "^4.17.5",

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -58,6 +58,7 @@ function selectAppArgs(options) {
     alwaysOnTop: options.alwaysOnTop,
     titleBarStyle: options.titleBarStyle,
     globalShortcuts: options.globalShortcuts,
+    darwinDarkModeSupport: options.darwinDarkModeSupport,
   };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -238,6 +238,10 @@ if (require.main === module) {
       '--global-shortcuts <value>',
       'JSON file with global shortcut configuration. See https://github.com/jiahaog/nativefier/blob/master/docs/api.md#global-shortcuts',
     )
+    .option(
+      '--darwin-dark-mode-support',
+      "(macOS only) enable Dark Mode support on macOS 10.14+",
+    )
     .parse(sanitizedArgs);
 
   if (!process.argv.slice(2).length) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -240,7 +240,7 @@ if (require.main === module) {
     )
     .option(
       '--darwin-dark-mode-support',
-      "(macOS only) enable Dark Mode support on macOS 10.14+",
+      '(macOS only) enable Dark Mode support on macOS 10.14+',
     )
     .parse(sanitizedArgs);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 import path from 'path';
 
 export const DEFAULT_APP_NAME = 'APP';
-export const ELECTRON_VERSION = '3.1.7';
+export const ELECTRON_VERSION = '4.1.4';
 export const PLACEHOLDER_APP_DIR = path.join(__dirname, './../', 'app');

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 import path from 'path';
 
 export const DEFAULT_APP_NAME = 'APP';
-export const ELECTRON_VERSION = '4.1.4';
+export const ELECTRON_VERSION = '5.0.9';
 export const PLACEHOLDER_APP_DIR = path.join(__dirname, './../', 'app');

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 import path from 'path';
 
 export const DEFAULT_APP_NAME = 'APP';
-export const ELECTRON_VERSION = '5.0.9';
+export const ELECTRON_VERSION = '5.0.10';
 export const PLACEHOLDER_APP_DIR = path.join(__dirname, './../', 'app');

--- a/src/helpers/packagerConsole.js
+++ b/src/helpers/packagerConsole.js
@@ -6,6 +6,7 @@ class PackagerConsole {
     this.logs = [];
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   _log(...messages) {
     this.logs.push(...messages);
   }

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -77,6 +77,7 @@ export default function(inpOptions) {
     alwaysOnTop: inpOptions.alwaysOnTop || false,
     titleBarStyle: inpOptions.titleBarStyle || null,
     globalShortcuts: inpOptions.globalShortcuts || null,
+    darwinDarkModeSupport: inpOptions.darwinDarkModeSupport || false,
   };
 
   if (options.verbose) {


### PR DESCRIPTION
This PR adds support for Dark Mode on macOS 10.4+. This was done by introducing the `--darwin-dark-mode-support` flag. Flag name is up for discussion - I kept the same flag used by Electron Packager. This also includes version bumps for Electron and Electron Packager (necessary for Dark Mode support).

Addresses:

- https://github.com/jiahaog/nativefier/issues/733
- https://github.com/jiahaog/nativefier/issues/727