### PR TITLE
Support setting background color (fixes #795)

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -125,7 +125,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         alwaysOnTop: options.alwaysOnTop,
         titleBarStyle: options.titleBarStyle,
         show: options.tray !== 'start-in-tray',
-        backroundColor: options.backroundColor,
+        backgroundColor: options.backgroundColor,
       },
       DEFAULT_WINDOW_OPTIONS,
     ),

--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -125,6 +125,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         alwaysOnTop: options.alwaysOnTop,
         titleBarStyle: options.titleBarStyle,
         show: options.tray !== 'start-in-tray',
+        backroundColor: options.backroundColor,
       },
       DEFAULT_WINDOW_OPTIONS,
     ),

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@
     - [[always-on-top]](#always-on-top)
     - [[global-shortcuts]](#global-shortcuts)
     - [[darwin-dark-mode-support]](#darwin-dark-mode-support)
+    - [[background-color]](#background-color)
 - [Programmatic API](#programmatic-api)
   - [Addition packaging options for Windows](#addition-packaging-options-for-windows)
     - [[version-string]](#version-string)
@@ -702,6 +703,14 @@ Example `shortcuts.json` for `https://deezer.com` & `https://soundcloud.com` to 
 ```
 
 Enables Dark Mode support on macOS 10.4+.
+
+#### [background-color]
+
+```
+--background-color
+```
+
+See https://electronjs.org/docs/api/browser-window#setting-backgroundcolor
 
 ## Programmatic API
 

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -58,6 +58,7 @@ function selectAppArgs(options) {
     alwaysOnTop: options.alwaysOnTop,
     titleBarStyle: options.titleBarStyle,
     globalShortcuts: options.globalShortcuts,
+    backgroundColor: options.backgroundColor,
   };
 }
 
@@ -133,6 +134,7 @@ function changeAppPackageJsonName(appPath, name, url) {
  */
 function buildApp(src, dest, options, callback) {
   const appArgs = selectAppArgs(options);
+
   copy(src, dest, (error) => {
     if (error) {
       callback(`Error Copying temporary directory: ${error}`);

--- a/src/cli.js
+++ b/src/cli.js
@@ -238,6 +238,10 @@ if (require.main === module) {
       '--global-shortcuts <value>',
       'JSON file with global shortcut configuration. See https://github.com/jiahaog/nativefier/blob/master/docs/api.md#global-shortcuts',
     )
+    .option(
+      '--backgroundColor <value>',
+      'Sets a background color of the window whilest the app is still loading',
+    )
     .parse(sanitizedArgs);
 
   if (!process.argv.slice(2).length) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -239,7 +239,7 @@ if (require.main === module) {
       'JSON file with global shortcut configuration. See https://github.com/jiahaog/nativefier/blob/master/docs/api.md#global-shortcuts',
     )
     .option(
-      '--backgroundColor <value>',
+      '--background-color <value>',
       "Sets the background color (for seamless experience while the app is loading). Example value: '#2e2c29'",
     )
     .option(

--- a/src/cli.js
+++ b/src/cli.js
@@ -240,7 +240,7 @@ if (require.main === module) {
     )
     .option(
       '--backgroundColor <value>',
-      "Sets the background color (for seamless experience while the app is loading)",
+      "Sets the background color (for seamless experience while the app is loading). Example value: '#2e2c29'",
     )
     .option(
       '--darwin-dark-mode-support',

--- a/src/cli.js
+++ b/src/cli.js
@@ -240,7 +240,7 @@ if (require.main === module) {
     )
     .option(
       '--backgroundColor <value>',
-      'Sets a background color of the window whilest the app is still loading',
+      "Sets the background color (for seamless experience while the app is loading)",
     )
     .parse(sanitizedArgs);
 

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -77,6 +77,7 @@ export default function(inpOptions) {
     alwaysOnTop: inpOptions.alwaysOnTop || false,
     titleBarStyle: inpOptions.titleBarStyle || null,
     globalShortcuts: inpOptions.globalShortcuts || null,
+    backgroundColor: inpOptions.backgroundColor,
   };
 
   if (options.verbose) {


### PR DESCRIPTION
Closes issue #795

Adds a backgroundColor flag for the background of the window when the app isn't loaded