### PR TITLE
Restore login functionality broken since Electron 5.x

### DIFF
--- a/app/src/components/login/loginWindow.js
+++ b/app/src/components/login/loginWindow.js
@@ -7,6 +7,9 @@ function createLoginWindow(loginCallback) {
     height: 400,
     frame: false,
     resizable: false,
+    webPreferences: {
+      nodeIntegration: true,
+    },
   });
   loginWindow.loadURL(
     `file://${path.join(__dirname, '/static/login/login.html')}`,


### PR DESCRIPTION
nodeIntegration is required if eg. Javascript code makes use of the
`require` expression to import classes into the current scope. login.js
uses an electron import - without it, the callback mechanism does not
work, and thus the whole login functionality.

Electron seems to have changed the default value for a windows `nodeIntegration` to `false` since version 5 (see https://stackoverflow.com/questions/55093700/electron-5-0-0-uncaught-referenceerror-require-is-not-defined)

Without the integration, the login component's functionality is broken, though. This PR enables the nodeIntegration feature for the login window and makes it properly propagate the given credentials.

Tested with Electron 6.0.0 on Linux.