### PR TITLE
Add --browserwindow-options to completely expose Electron options

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -104,6 +104,8 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
     },
   };
 
+  const browserwindowOptions = Object.assign({}, options.browserwindowOptions);
+
   const mainWindow = new BrowserWindow(
     Object.assign(
       {
@@ -127,6 +129,7 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
         show: options.tray !== 'start-in-tray',
       },
       DEFAULT_WINDOW_OPTIONS,
+      browserwindowOptions,
     ),
   );
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -702,7 +702,7 @@ Example `shortcuts.json` for `https://deezer.com` & `https://soundcloud.com` to 
 ```
 
 a JSON string that will be sent directly into electron BrowserWindow options.
-See [Electron's BrowserWindow API Documentation](https://github.com/electron/electron/blob/3-1-x/docs/api/browser-window.md#new-browserwindowoptions) for the complete list of options.
+See [Electron's BrowserWindow API Documentation](https://electronjs.org/docs/api/browser-window#new-browserwindowoptions) for the complete list of options.
 
 Example:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -64,6 +64,7 @@
     - [[file-download-options]](#file-download-options)
     - [[always-on-top]](#always-on-top)
     - [[global-shortcuts]](#global-shortcuts)
+    - [[browserwindow-options]](#browserwindow-options)
 - [Programmatic API](#programmatic-api)
   - [Addition packaging options for Windows](#addition-packaging-options-for-windows)
     - [[version-string]](#version-string)
@@ -692,6 +693,21 @@ Example `shortcuts.json` for `https://deezer.com` & `https://soundcloud.com` to 
     ]
   }
 ]
+```
+
+#### [browserwindow-options]
+
+```
+--browserwindow-options <json-string>
+```
+
+a JSON string that will be sent directly into electron BrowserWindow options.
+See [Electron's BrowserWindow API Documentation](https://github.com/electron/electron/blob/3-1-x/docs/api/browser-window.md#new-browserwindowoptions) for the complete list of options.
+
+Example:
+
+```bash
+nativefier <your-website> --browserwindow-options '{ "webPreferences": { "defaultFontFamily": { "standard": "Comic Sans MS", "serif": "Comic Sans MS" } } }'
 ```
 
 

--- a/src/build/buildApp.js
+++ b/src/build/buildApp.js
@@ -58,6 +58,7 @@ function selectAppArgs(options) {
     alwaysOnTop: options.alwaysOnTop,
     titleBarStyle: options.titleBarStyle,
     globalShortcuts: options.globalShortcuts,
+    browserwindowOptions: options.browserwindowOptions,
   };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -238,6 +238,11 @@ if (require.main === module) {
       '--global-shortcuts <value>',
       'JSON file with global shortcut configuration. See https://github.com/jiahaog/nativefier/blob/master/docs/api.md#global-shortcuts',
     )
+    .option(
+      '--browserwindow-options <json-string>',
+      'a JSON string that will be sent directly into electron BrowserWindow options. See https://github.com/jiahaog/nativefier/blob/master/docs/api.md#browserwindow-options',
+      parseJson,
+    )
     .parse(sanitizedArgs);
 
   if (!process.argv.slice(2).length) {

--- a/src/helpers/packagerConsole.js
+++ b/src/helpers/packagerConsole.js
@@ -6,6 +6,7 @@ class PackagerConsole {
     this.logs = [];
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   _log(...messages) {
     this.logs.push(...messages);
   }

--- a/src/options/optionsMain.js
+++ b/src/options/optionsMain.js
@@ -77,6 +77,7 @@ export default function(inpOptions) {
     alwaysOnTop: inpOptions.alwaysOnTop || false,
     titleBarStyle: inpOptions.titleBarStyle || null,
     globalShortcuts: inpOptions.globalShortcuts || null,
+    browserwindowOptions: inpOptions.browserwindowOptions,
   };
 
   if (options.verbose) {


### PR DESCRIPTION
This PR adds a new option to the CLI (`--browserwindow-options`), taking a stringified JSON object as input.  
It will be inserted directly into the options when BrowserConfig is initialised in `/app/src/components/mainWindow/mainWindow.js`.

This allows total configurability of the electron BrowserWindow configuration via `nativefier`.

An example use case is added to the documentation, which modifies the default font family in the browser.

#### References
- https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions
  - See the following for electron v3.1.7
  - https://github.com/electron/electron/blob/v3.1.7/docs/api/browser-window.md#new-browserwindowoptions