### PR TITLE
Pass filter argument to onHeadersReceived() strictly

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -58,7 +58,7 @@ function maybeInjectCss(browserWindow) {
     // we have to inject the css in onHeadersReceived so they're early enough
     // will run multiple times, so did-finish-load will remove this handler
     browserWindow.webContents.session.webRequest.onHeadersReceived(
-      [], // Pass an empty filter list; null will not match _any_ urls
+      { urls: [] }, // Pass an empty filter list; null will not match _any_ urls
       onHeadersReceived,
     );
   });


### PR DESCRIPTION
When inject css below error causes by [this change of electron](https://github.com/electron/electron/pull/19337/files)

![image](https://user-images.githubusercontent.com/599164/63574823-a3dd6180-c5c3-11e9-89c0-a9debdd4f696.png)

So pass filter argument object with strictly structure.