### PR TITLE
Fix weirdly platform-dependent folder naming logic (PR #850, fix #708)

### DIFF
--- a/src/utils/sanitizeFilename.js
+++ b/src/utils/sanitizeFilename.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import sanitizeFilenameLib from 'sanitize-filename';
 import { DEFAULT_APP_NAME } from '../constants';
 
@@ -11,7 +10,7 @@ export default function(platform, str) {
 
   // spaces will cause problems with Ubuntu when pinned to the dock
   if (platform === 'linux') {
-    return result.replace(' ','');
+    return result.replace(' ', '');
   }
   return result;
 }

--- a/src/utils/sanitizeFilename.js
+++ b/src/utils/sanitizeFilename.js
@@ -10,7 +10,7 @@ export default function(platform, str) {
 
   // spaces will cause problems with Ubuntu when pinned to the dock
   if (platform === 'linux') {
-    return result.replace(' ', '');
+    return result.replace(/ /g, '');
   }
   return result;
 }

--- a/src/utils/sanitizeFilename.js
+++ b/src/utils/sanitizeFilename.js
@@ -11,7 +11,7 @@ export default function(platform, str) {
 
   // spaces will cause problems with Ubuntu when pinned to the dock
   if (platform === 'linux') {
-    return _.kebabCase(result);
+    return result.replace(' ','');
   }
   return result;
 }

--- a/src/utils/sanitizeFilename.test.js
+++ b/src/utils/sanitizeFilename.test.js
@@ -27,9 +27,9 @@ describe('replacing non ascii characters', () => {
 });
 
 describe('when the platform is linux', () => {
-  test('it should return a kebab cased name', () => {
+  test('it should return a name without spaces', () => {
     const param = 'some name';
-    const expectedResult = 'some-name';
+    const expectedResult = 'somename';
     const result = sanitizeFilename('linux', param);
     expect(result).toBe(expectedResult);
   });


### PR DESCRIPTION
For issue #708 

- Changed Kebab casing to removal of space in string for the specific case of Linux platform

- For the issue specifying the directory name as `win32-x64`, I'm not sure if we can edit the platform name directly, since it is the convention followed by electron in its naming.

- Corresponding test also edited as well.