### PR TITLE
app: handle nativefier.json readonly access with options.maximize (Issue #855)

### DIFF
--- a/app/src/components/mainWindow/mainWindow.js
+++ b/app/src/components/mainWindow/mainWindow.js
@@ -140,10 +140,15 @@ function createMainWindow(inpOptions, onAppQuit, setDockBadge) {
   if (options.maximize) {
     mainWindow.maximize();
     options.maximize = undefined;
-    fs.writeFileSync(
-      path.join(__dirname, '..', 'nativefier.json'),
-      JSON.stringify(options),
-    );
+    try {
+      fs.writeFileSync(
+        path.join(__dirname, '..', 'nativefier.json'),
+        JSON.stringify(options),
+      );
+    } catch (exception) {
+      // eslint-disable-next-line no-console
+      console.log(`WARNING: Ignored nativefier.json rewrital (${exception})`);
+    }
   }
 
   const withFocusedWindow = (block) => {


### PR DESCRIPTION
**Resolves #855**

**Example result upon Terminal launch:**

`WARNING: Ignored nativefier.json rewrital (Error: EACCES: permission denied, open '/usr/lib/jupyter-remote-client/resources/app/nativefier.json')`

**Behaviour:**

+ Instead of crashing, the application properly opens and is always maximized.

+ When permissions are R/W, the application is maximized on first launch and the closing states are remembered by the OS throughout launches.