### PR TITLE
app: fix: nativefier application menu support on Electron 5.0

### DIFF
--- a/app/src/components/menu/menu.js
+++ b/app/src/components/menu/menu.js
@@ -26,9 +26,6 @@ function createMenu({
   clearAppData,
   disableDevTools,
 }) {
-  if (Menu.getApplicationMenu()) {
-    return;
-  }
   const zoomResetLabel =
     zoomBuildTimeValue === 1.0
       ? 'Reset Zoom'


### PR DESCRIPTION
**Resolves #875**

**Details:**

* Electron 5.0 always defines a default application menu
* The menu.js safeguard ignores nativefier's menu due to this new default menu
* The safeguard removal allows the nativefier menu to be created
* The nativefier menu respects `disableDevTools = true` as before