### PR TITLE
Fix #903: JS error when using Electron 7+ and --tray (PR #904)

### DIFF
--- a/app/src/components/trayIcon/trayIcon.js
+++ b/app/src/components/trayIcon/trayIcon.js
@@ -39,14 +39,6 @@ function createTrayIcon(inpOptions, mainWindow) {
 
     appIcon.on('click', onClick);
 
-    mainWindow.on('show', () => {
-      appIcon.setHighlightMode('always');
-    });
-
-    mainWindow.on('hide', () => {
-      appIcon.setHighlightMode('never');
-    });
-
     if (options.counter) {
       mainWindow.on('page-title-updated', (e, title) => {
         const counterValue = getCounterValue(title);


### PR DESCRIPTION
The API `tray.setHighlightMode(mode)` has been be removed in electron v7.0
without replacement.
This causes the display of an error dialog every time an app is
shown/hidden if the parameter `--tray` is used when nativefying. This is
completely independent form the website you are nativefying and it
happens with all the version of electron after 6.x.

source: https://www.electronjs.org/docs/api/breaking-changes#tray