### PR TITLE
add loglevel to external dependencies

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -22,6 +22,7 @@ module.exports = {
   // app by electron-packager. https://webpack.js.org/configuration/externals/
   externals: {
     electron: 'commonjs electron',
+    loglevel: 'commonjs loglevel',
   },
   resolve: {
     extensions: [ '.ts', '.js' ],


### PR DESCRIPTION
Fixes loglevel dependency error in preload.js.  Re-enables script injection.