### PR TITLE
Fix: notifications (fix #88, fix #956), processEnvs, using as git

### DIFF
--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -24,10 +24,15 @@ const fileDownloadOptions = { ...appArgs.fileDownloadOptions };
 electronDownload(fileDownloadOptions);
 
 if (appArgs.processEnvs) {
-  Object.keys(appArgs.processEnvs).forEach((key) => {
-    /* eslint-env node */
-    process.env[key] = appArgs.processEnvs[key];
-  });
+  // This is compatibility if just a string was passed.
+  if (typeof appArgs.processEnvs === 'string') {
+    process.env.processEnvs = appArgs.processEnvs;
+  } else {
+    Object.keys(appArgs.processEnvs).forEach((key) => {
+      /* eslint-env node */
+      process.env[key] = appArgs.processEnvs[key];
+    });
+  }
 }
 
 let mainWindow;

--- a/app/src/preload.ts
+++ b/app/src/preload.ts
@@ -22,7 +22,7 @@ const INJECT_JS_PATH = path.join(__dirname, '..', 'inject/inject.js');
  */
 function setNotificationCallback(createCallback, clickCallback) {
   const OldNotify = window.Notification;
-  const newNotify = (title, opt) => {
+  const newNotify = function (title, opt) {
     createCallback(title, opt);
     const instance = new OldNotify(title, opt);
     instance.addEventListener('click', clickCallback);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint:format": "prettier --write 'src/**/*.js' 'app/src/**/*.js'",
     "lint": "eslint . --ext .ts",
     "list-outdated-deps": "npm out; cd app && npm out; true",
+    "prepare": "cd ./app && npm install && cd .. && npm run build",
     "test:integration": "jest --testRegex '.*integration-test.js'",
     "test:manual": "npm run build && ./docs/manual-test",
     "test:unit": "jest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ function getProcessEnvs(val: string): any {
   if (!val) {
     return {};
   }
-  return { processEnvs: parseJson(val) };
+  return parseJson(val);
 }
 
 function checkInternet(): void {


### PR DESCRIPTION
1. Fix (broken since 2016): Notifications broken by lambda constructor
2. Fix: `--processEnvs` broken by additional processEnvs object, the result was:
`processEnvs: {processEnvs: {...}}` which caused the conversion of the inner object into string `[object Object]`, no nesting allowed there probably. Compatibility introduced.
3. Fix: package.json missing `prepare` (or even prepublish), which breaks using as git dependency.