### PR TITLE
use sandbox when loading untrusted web content

### DIFF
--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -95,6 +95,7 @@ export function createMainWindow(
       plugins: true,
       nodeIntegration: false, // `true` is *insecure*, and cause trouble with messenger.com
       webSecurity: !options.insecure,
+      sandbox: true,
       preload: path.join(__dirname, 'preload.js'),
       zoomFactor: options.zoom,
     },


### PR DESCRIPTION
https://www.electronjs.org/docs/api/sandbox-option

> One of the key security features of Chromium is that all blink rendering/JavaScript code is executed within a sandbox. This sandbox uses OS-specific features to ensure that exploits in the renderer process cannot harm the system.


> In other words, when the sandbox is enabled, the renderers can only make changes to the system by delegating tasks to the main process via IPC. Here's more information about the sandbox.


> Usually this is not a problem for desktop applications since the code is always trusted, but it makes Electron less secure than Chromium for displaying untrusted web content. For applications that require more security, the sandbox flag will force Electron to spawn a classic Chromium renderer that is compatible with the sandbox.


fixes https://github.com/jiahaog/nativefier/issues/756