### PR TITLE
Bumped up NODE docker image version from 8 to 12.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-stretch
+FROM node:12.18.1-stretch
 LABEL description="Debian image to build nativefier apps"
 
 # Get wine32, not 64, to work around binary incompatibility with rcedit.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.1-stretch
+FROM node:12-stretch
 LABEL description="Debian image to build nativefier apps"
 
 # Get wine32, not 64, to work around binary incompatibility with rcedit.


### PR DESCRIPTION
Updated Node version in the Dockerfile from 8-stretch to 12.18.1-stretch. 12.18.1 is currently the most recent LTS version of NodeJS.