### PR TITLE
[dev] Add unified {build,test} watch mode, using "concurrently"

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,4 +67,7 @@ but is painful to do manually. Do yourself a favor and install a
 - To run only integration tests, `npm run test:integration`
 - Logging is suppressed by default in tests, to avoid polluting Jest output.
   To get debug logs, `npm run test:withlog` or set the `LOGLEVEL` env. var.
-- For a good live experience, run both the build and tests in watch mode: `npm run watch`
+- For a good live experience, open two terminal panes/tabs running code/tests watchers:
+  1. Run a TSC watcher: `npm run build:watch`
+  2. Run a Jest unit tests watcher: `npm run test:watch`
+- Alternatively, you can run both test processes in the same terminal by running: `npm run watch`

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,8 @@ After doing so, you can run Nativefier with your test parameters:
 nativefier --your-awesome-new-flag 'https://your-test-site.com'
 ```
 
-Then run your nativefier app *through the command line too* (to see logs & errors):
+Then run your nativefier app _through the command line too_ (to see logs & errors):
+
 ```bash
 # Under Linux
 ./your-test-site-linux-x64/your-test-site
@@ -66,6 +67,4 @@ but is painful to do manually. Do yourself a favor and install a
 - To run only integration tests, `npm run test:integration`
 - Logging is suppressed by default in tests, to avoid polluting Jest output.
   To get debug logs, `npm run test:withlog` or set the `LOGLEVEL` env. var.
-- For a good live experience, open two terminal panes/tabs running code/tests watchers:
-    1. Run a TSC watcher: `npm run build:watch`
-    2. Run a Jest unit tests watcher: `npm run test:watch`
+- For a good live experience, run both the build and tests in watch mode: `npm run watch`

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test:unit": "jest",
     "test:watch": "jest --watch",
     "test:withlog": "LOGLEVEL=trace npm run test",
-    "test": "jest --testRegex '[-.]test\\.js$'"
+    "test": "jest --testRegex '[-.]test\\.js$'",
+    "watch": "concurrently \"npm:*:watch\""
   },
   "dependencies": {
     "@types/cheerio": "0.x",
@@ -77,6 +78,7 @@
     "@types/jest": "26.x",
     "@typescript-eslint/eslint-plugin": "3.x",
     "@typescript-eslint/parser": "3.x",
+    "concurrently": "^5.2.0",
     "eslint": "7.x",
     "eslint-config-prettier": "6.x",
     "eslint-plugin-prettier": "3.x",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@types/jest": "26.x",
     "@typescript-eslint/eslint-plugin": "3.x",
     "@typescript-eslint/parser": "3.x",
-    "concurrently": "^5.2.0",
     "eslint": "7.x",
     "eslint-config-prettier": "6.x",
     "eslint-plugin-prettier": "3.x",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:watch": "jest --watch",
     "test:withlog": "LOGLEVEL=trace npm run test",
     "test": "jest --testRegex '[-.]test\\.js$'",
-    "watch": "concurrently \"npm:*:watch\""
+    "watch": "npx concurrently \"npm:*:watch\""
   },
   "dependencies": {
     "@types/cheerio": "0.x",


### PR DESCRIPTION
I noticed that the development README suggested using multiple console windows/tabs for a good development experience.  Using the package `concurrently`, we can streamline that and require only one window with output for both watch processes:
![image](https://user-images.githubusercontent.com/12286274/88694827-477d9e80-d0be-11ea-898c-ee9a509db4bb.png)
