### PR TITLE
Typescript types

### DIFF
--- a/src/build/buildNativefierApp.ts
+++ b/src/build/buildNativefierApp.ts
@@ -9,7 +9,7 @@ import { isWindows, getTempDir, copyFileOrDir } from '../helpers/helpers';
 import { getOptions } from '../options/optionsMain';
 import { prepareElectronApp } from './prepareElectronApp';
 import { convertIconIfNecessary } from './buildIcon';
-import { AppOptions } from '../options/model';
+import { AppOptions, NativefierOptions } from '../options/model';
 
 const OPTIONS_REQUIRING_WINDOWS_FOR_WINDOWS_BUILD = [
   'icon',
@@ -99,7 +99,9 @@ function trimUnprocessableOptions(options: AppOptions): void {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function buildNativefierApp(rawOptions: any): Promise<string> {
+export async function buildNativefierApp(
+  rawOptions: NativefierOptions,
+): Promise<string> {
   log.info('Processing options...');
   const options = await getOptions(rawOptions);
 

--- a/src/options/model.ts
+++ b/src/options/model.ts
@@ -56,3 +56,7 @@ export interface AppOptions {
     zoom: number;
   };
 }
+
+export type NativefierOptions = Partial<
+  AppOptions['packager'] & AppOptions['nativefier']
+>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
       "allowJs": false,
-      "declaration": false,
+      "declaration": true,
       "incremental": true,
       "module": "commonjs",
       "moduleResolution": "node",


### PR DESCRIPTION
This PR adds better Typescript support when using the Node module directly:
1. Generate type declarations when running `tsc`
2. Created the `NativefierOptions` type for the `buildNativefierApp` function instead of using `any`