### PR TITLE
Bump default Electron to 10.1.5 (with Chromium 85.0.4183.121)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 export const DEFAULT_APP_NAME = 'APP';
 
 // Update both together
-export const DEFAULT_ELECTRON_VERSION = '10.1.0';
-export const DEFAULT_CHROME_VERSION = '85.0.4183.87';
+export const DEFAULT_ELECTRON_VERSION = '10.1.5';
+export const DEFAULT_CHROME_VERSION = '85.0.4183.121';
 
 export const ELECTRON_MAJOR_VERSION = parseInt(
   DEFAULT_ELECTRON_VERSION.split('.')[0],


### PR DESCRIPTION
Fixes [CVE-2020-15999](https://github.com/advisories/GHSA-pv36-h7jh-qm62) Heap overflow in the freetype library by upgrading to Electron [10.1.5](https://github.com/electron/electron/releases/tag/v10.1.5) 

https://github.com/electron/electron/pull/26070
