### PR TITLE
Correctly start in tray when both --maximize and --tray start-in-tray are passed (fix #1015)

### DIFF
--- a/app/src/components/mainWindow.ts
+++ b/app/src/components/mainWindow.ts
@@ -146,6 +146,10 @@ export function createMainWindow(
     }
   }
 
+  if (options.tray === 'start-in-tray') {
+    mainWindow.hide();
+  }
+
   const withFocusedWindow = (block: (window: BrowserWindow) => void): void => {
     const focusedWindow = BrowserWindow.getFocusedWindow();
     if (focusedWindow) {


### PR DESCRIPTION
Correctly handle window options when both `--maximize` and `--tray start-in-tray` are selected.