### PR TITLE
Types moved into dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "source-map-support": "0.x",
     "tmp": "0.x"
   },
-  "devDependencies": {    
+  "devDependencies": {
     "@types/ncp": "2.x",
     "@types/node": "10.x",
     "@types/page-icon": "0.x",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,6 @@
     "watch": "npx concurrently \"npm:*:watch\""
   },
   "dependencies": {
-    "@types/ncp": "2.x",
-    "@types/node": "10.x",
-    "@types/page-icon": "0.x",
-    "@types/shelljs": "0.x",
-    "@types/tmp": "0.x",
     "axios": "0.x",
     "commander": "4.x",
     "electron-packager": "15.x",
@@ -71,7 +66,12 @@
     "source-map-support": "0.x",
     "tmp": "0.x"
   },
-  "devDependencies": {
+  "devDependencies": {    
+    "@types/ncp": "2.x",
+    "@types/node": "10.x",
+    "@types/page-icon": "0.x",
+    "@types/shelljs": "0.x",
+    "@types/tmp": "0.x",
     "@types/jest": "26.x",
     "@typescript-eslint/eslint-plugin": "4.x",
     "@typescript-eslint/parser": "4.x",


### PR DESCRIPTION
Hello! 👋

This is a tiny PR, and it just moves @types/* into dev dependencies. This doesn't effect the code, it'll just speed up installation as there are now less dependencies.

Thank you, have a great day! 😉